### PR TITLE
feat: Migrate domain to `https://eva.town`

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test --project="Google Chrome"
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitFor200.outputs.url || 'https://evadecker.com' }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitFor200.outputs.url || 'https://eva.town' }}
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 <div align="center">
 
-![Vercel](https://vercelbadge.vercel.app/api/evadecker/evadecker.com) [![Playwright](https://github.com/evadecker/evadecker.com/actions/workflows/playwright.yml/badge.svg)](https://github.com/evadecker/evadecker.com/actions/workflows/playwright.yml) [![HTML5 Validation](https://github.com/evadecker/evadecker.com/actions/workflows/w3c.yml/badge.svg)](https://github.com/evadecker/evadecker.com/actions/workflows/w3c.yml) ![GitHub](https://img.shields.io/github/license/evadecker/evadecker.com)
+![Vercel](https://vercelbadge.vercel.app/api/evadecker/eva.town) [![Playwright](https://github.com/evadecker/eva.town/actions/workflows/playwright.yml/badge.svg)](https://github.com/evadecker/eva.town/actions/workflows/playwright.yml) [![HTML5 Validation](https://github.com/evadecker/eva.town/actions/workflows/w3c.yml/badge.svg)](https://github.com/evadecker/eva.town/actions/workflows/w3c.yml) ![GitHub](https://img.shields.io/github/license/evadecker/eva.town)
 
 </div>
 
 # Eva Decker
 
-This is the source code for https://evadecker.com, designed, coded, and written by Eva—that's me! It's a place for me to share notes and learn in public. I try to update things regularly.
+This is the source code for https://eva.town, designed, coded, and written by Eva—that's me! It's a place for me to share notes and learn in public. I try to update things regularly.
 
 You're welcome to fork this site, use it as inspiration, and modify things for your own projects—just don't steal it or try to claim my work as your own. That's not cool.
 
-For information about the technology and tools behind this site, visit [https://evadecker.com/colophon](https://evadecker.com/colophon).
+For information about the technology and tools behind this site, visit [https://eva.town/colophon](https://eva.town/colophon).
 
 ## Getting Started
 
@@ -52,5 +52,5 @@ The primary images on pages use Atkinson dithering. I'd like to automate this pi
 5. Export the file as `.webp`. I like to prefix the size at the end of the image, like `img1200.webp`.
 6. Resize your image again, down to 900px. Repeat the steps in Dithermark for the new image and export another `.webp`.
 7. Repeat the same steps for 600px.
-8. Add the images to the content directory and link them from the frontmatter as an array, [like this](https://github.com/evadecker/evadecker.com/blob/9257f833528852114ffa88cb4907113697072b43/src/content/pages/about/index.md?plain=1#L6).
+8. Add the images to the content directory and link them from the frontmatter as an array, [like this](https://github.com/evadecker/eva.town/blob/9257f833528852114ffa88cb4907113697072b43/src/content/pages/about/index.md?plain=1#L6).
 9. Add an `imgAlt` in the frontmatter.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 # Eva Decker
 
-This is the source code for https://eva.town, designed, coded, and written by Eva—that's me! It's a place for me to share notes and learn in public. I try to update things regularly.
+This is the source code for [eva.town](https://eva.town), designed, coded, and written by Eva—that's me! It's a place for me to share notes and learn in public. I try to update things regularly.
 
 You're welcome to fork this site, use it as inspiration, and modify things for your own projects—just don't steal it or try to claim my work as your own. That's not cool.
 
-For information about the technology and tools behind this site, visit [https://eva.town/colophon](https://eva.town/colophon).
+For information about the technology and tools behind this site, visit [eva.town/colophon](https://eva.town/colophon).
 
 ## Getting Started
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,7 +9,7 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import { autolinkConfig } from "./plugins/rehype-autolink-config";
 
 export default defineConfig({
-  site: "https://evadecker.com",
+  site: "https://eva.town",
   integrations: [react(), mdx(), sitemap()],
   adapter: vercel({
     webAnalytics: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "evadecker.com",
+  "name": "eva.town",
   "version": "0.0.1",
   "private": true,
   "engines": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://evadecker.com/sitemap-index.xml
+Sitemap: https://eva.town/sitemap-index.xml

--- a/src/content/pages/colophon/index.md
+++ b/src/content/pages/colophon/index.md
@@ -1,6 +1,6 @@
 ---
 title: Colophon
-description: Colophon is a designer-y word for “how it’s made”—here’s what powers evadecker.com.
+description: Colophon is a designer-y word for “how it’s made”—here’s what powers eva.town.
 datePublished: 2023-09-26 03:47:00-04:00
 dateModified: 2023-10-19 04:26:15-04:00
 img: ["./img600.webp", "./img900.webp", "./img1200.webp"]
@@ -12,7 +12,7 @@ ogImage: ./img1200.webp
 
 I designed and built this site myself. It's a home to share things I'm exploring and things I've built. It's a place for me to learn in public.
 
-All code is open source and available on [GitHub](https://github.com/evadecker/evadecker.com). The first commit was December 5, 2018, but the earliest version of this site dates back to 2015, an era when I eschewed versioning and uploaded files manually via <abbr title="File Transfer Protocol">FTP</abbr>. I've grown a lot since then—and the technology around me has grown, too.
+All code is open source and available on [GitHub](https://github.com/evadecker/eva.town). The first commit was December 5, 2018, but the earliest version of this site dates back to 2015, an era when I eschewed versioning and uploaded files manually via <abbr title="File Transfer Protocol">FTP</abbr>. I've grown a lot since then—and the technology around me has grown, too.
 
 ## Technology
 
@@ -50,8 +50,8 @@ I minimize energy usage on this site by avoiding unnecessary scripts (such as tr
 > The internet consumes a lot of electricity. 416.2TWh per year to be precise. To give you some perspective, that's more than the entire United Kingdom.
 > <cite>[Website Carbon Calculator](https://www.websitecarbon.com)</cite>
 
-As of October 18, 2023, [carbon results for evadecker.com](https://www.websitecarbon.com/website/evadecker-com/) indicate that the home page is **cleaner than 95% of web pages tested**, producing **0.05g of CO<sub>2</sub> per page view**. The site uses [Vercel's serverless architecture](https://vercel.com/guides/what-is-vercel-green-energy-policy#) to further cut energy consumption.
+As of October 18, 2023, [carbon results for eva.town](https://www.websitecarbon.com/website/eva-town/) indicate that the home page is **cleaner than 95% of web pages tested**, producing **0.05g of CO<sub>2</sub> per page view**. The site uses [Vercel's serverless architecture](https://vercel.com/guides/what-is-vercel-green-energy-policy#) to further cut energy consumption.
 
 ## Notice an issue?
 
-If you spot a typo, encounter a broken feature, or have a recommendation for an improvement, [file an issue on GitHub](https://github.com/evadecker/evadecker.com/issues).
+If you spot a typo, encounter a broken feature, or have a recommendation for an improvement, [file an issue on GitHub](https://github.com/evadecker/eva.town/issues).


### PR DESCRIPTION
- New, shorter domain
- https://evadecker.com will redirect
- Email remains unchanged for now