### PR TITLE
feat: Add project CTAs

### DIFF
--- a/src/components/ProjectPreview.astro
+++ b/src/components/ProjectPreview.astro
@@ -1,78 +1,63 @@
 ---
 import { Image } from "astro:assets";
+import type { CollectionEntry } from "astro:content";
 
 import { smartquotes } from "../helpers/helpers";
 import { Icon } from "./Icon/Icon";
 
 interface Props {
-  title: string;
-  description: string;
-  datePublished: Date;
-  url?: string;
-  repo?: string;
-  img?: ImageMetadata;
-  imgAlt?: string;
-  video?: string;
-  videoPoster?: string;
-  disabled?: boolean;
+  project: CollectionEntry<"projects">;
 }
 
-const {
-  title,
-  description,
-  url,
-  repo,
-  img,
-  imgAlt,
-  video,
-  videoPoster,
-  disabled,
-} = Astro.props;
+const { project } = Astro.props;
+
+const { title, description, repo, img, video, cta } = project.data;
 ---
 
-<div class:list={["project", { disabled }]}>
+<div class="project">
+  {img && <Image src={img.src} alt={img.alt} class="img" />}
   {
-    img && imgAlt && (
-      <a class="img" href={url}>
-        <Image src={img} alt={imgAlt} />
-      </a>
-    )
-  }
-  {
-    video && videoPoster && (
+    video && (
       <video
         autoplay
         loop
         muted
         playsinline
         preload="none"
-        poster={videoPoster}
+        poster={video.poster}
       >
-        <source src={video} type="video/mp4" />
+        <source src={video.src} type="video/mp4" />
       </video>
     )
   }
   <div class="details">
-    <a class="title" href={url}>
-      <h3>{title}</h3>
-    </a>
-    <div class="description">
-      {smartquotes(description)}
+    <div class="details-text">
+      <h3 class="title">{title}</h3>
+      <div class="description">
+        {smartquotes(description)}
+      </div>
     </div>
-    <footer class="links">
+    <footer>
       {
-        url && (
-          <a class="link" href={url}>
-            <Icon icon="link" size="16" />
-            <span class="url">{url.replace(/^https?:\/\//, "")}</span>
+        cta && (
+          <a
+            class:list={["button", "cta", { disabled: cta.url === undefined }]}
+            href={cta.url}
+            target="_blank"
+            aria-disabled={cta.url === undefined}
+          >
+            {cta.text}
           </a>
         )
       }
       {
         repo && (
-          <a class="link" href={`https://github.com/${repo}`}>
-            <Icon icon="github" size="16" />
-            <span class="url">{repo}</span>
+          <a
+            class="button repo"
+            href={`https://github.com/${repo}`}
+            target="_blank"
+          >
+            <Icon icon="github" size="24" />
           </a>
         )
       }
@@ -98,19 +83,21 @@ const {
       border-radius: var(--radius-m);
       pointer-events: none;
     }
-
-    &.disabled {
-      opacity: 0.5;
-    }
   }
 
   .details {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--space-2xs);
+    gap: var(--space-m);
     padding: var(--space-m);
     width: 100%;
+  }
+
+  .details-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2xs);
   }
 
   .img {
@@ -120,7 +107,7 @@ const {
     line-height: 0;
   }
 
-  .title h3 {
+  h3 {
     font-size: var(--step-1);
   }
 
@@ -128,33 +115,45 @@ const {
     line-height: 1.3;
   }
 
-  .links {
+  footer {
     display: flex;
-    flex-flow: row wrap;
-    max-width: 100%;
-    column-gap: var(--space-m);
-    font-size: var(--step--1);
+    flex-flow: row;
+    width: 100%;
+    gap: var(--space-s);
   }
 
-  .link {
+  .button {
+    font-weight: var(--font-weight-medium);
+    background-color: var(--gray-2);
+    border: 1px solid var(--gray-a4);
+    color: var(--gray-11);
+    padding-inline: var(--space-m);
+    padding-block: var(--space-xs);
+    border-radius: var(--radius-s);
     display: flex;
     align-items: center;
-    gap: var(--space-2xs);
-    color: var(--gray-11);
-    padding-block: var(--space-2xs);
-    max-width: 100%;
-    line-height: 1.1;
+    justify-content: center;
 
-    &:hover {
-      color: var(--gray-12);
-      text-decoration: underline;
-      text-decoration-color: var(--gray-7);
-      text-underline-offset: 0.1em;
+    &.disabled {
+      opacity: 0.5;
     }
 
-    .url {
-      word-wrap: break-word;
-      min-width: 1%;
+    &.cta {
+      flex: 1;
     }
+  }
+
+  :global(.dark) .button {
+    background-color: var(--gray-4);
+    border-color: var(--gray-a2);
+  }
+
+  .button:not(.disabled):hover {
+    background-color: var(--gray-1);
+    color: var(--gray-12);
+  }
+
+  :global(.dark) .button:not(.disabled):hover {
+    background-color: var(--gray-5);
   }
 </style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -36,13 +36,23 @@ export const collections = {
         title: z.string(),
         description: z.string(),
         datePublished: z.date(),
-        img: image().optional(),
-        imgAlt: z.string().optional(),
-        video: z.string().optional(),
-        videoPoster: z.string().optional(),
-        url: z.string().optional(),
+        img: z
+          .object({
+            src: image(),
+            alt: z.string(),
+          })
+          .optional(),
+        video: z
+          .object({
+            src: z.string(),
+            poster: z.string(),
+          })
+          .optional(),
         repo: z.string().optional(), // GitHub repo, e.g. evadecker/america-my-face
-        draft: z.boolean().optional(),
+        cta: z.object({
+          text: z.string(),
+          url: z.string().optional(), // If no URL is set, button will be disabled
+        }),
       }),
   }),
 };

--- a/src/content/projects/america-my-face/index.yml
+++ b/src/content/projects/america-my-face/index.yml
@@ -1,7 +1,10 @@
 title: America, My Face
 description: It's saying everything you need to know.
 datePublished: 2021-09-29
-url: https://americamyfaceissayingeverythingthatyouneedtoknow.com
 repo: evadecker/america-my-face
-img: "./america-my-face.png"
-imgAlt: "Monique Heart from Ru Paul's Drag Race looks concerned."
+img:
+  src: "./america-my-face.png"
+  alt: "Monique Heart from Ru Paul's Drag Race looks concerned."
+cta:
+  text: Visit the site
+  url: https://americamyfaceissayingeverythingthatyouneedtoknow.com

--- a/src/content/projects/boundaries-map/index.yml
+++ b/src/content/projects/boundaries-map/index.yml
@@ -1,7 +1,10 @@
 title: NYC Boundaries Map
 description: View administrative boundaries in New York City—school districts, sanitation districts, police precincts, and more. Built with the team at BetaNYC.
 datePublished: 2022-06-30
-url: https://boundaries.beta.nyc
 repo: betanyc/nyc-boundaries
-video: "video/boundaries-map.mp4"
-videoPoster: "video/boundaries-map-poster.png"
+video:
+  src: "video/boundaries-map.mp4"
+  poster: "video/boundaries-map-poster.png"
+cta:
+  text: Visit the site
+  url: https://boundaries.beta.nyc

--- a/src/content/projects/commonplace/index.yml
+++ b/src/content/projects/commonplace/index.yml
@@ -1,5 +1,5 @@
 title: "Commonplace Design System"
-description: Design systems and product design work for Cityblock. Case study coming soon.
+description: Building a design system for Cityblock's care management tool, Commons.
 datePublished: 2020-06-01
-url: https://www.cityblock.com
-draft: true
+cta:
+  text: Case study coming soon

--- a/src/content/projects/design-is/index.yml
+++ b/src/content/projects/design-is/index.yml
@@ -1,6 +1,10 @@
 title: Design Is
 description: A choose-your-own-adventure poem about what it means to design.
 datePublished: 2024-02-02
-url: /design
-video: "video/design-is.mp4"
-videoPoster: "video/design-is-poster.png"
+video:
+  src: "video/design-is.mp4"
+  poster: "video/design-is-poster.png"
+cta:
+  text: Visit the site
+  url: /design
+repo: evadecker/eva.town/blob/main/src/pages/design/index.astro

--- a/src/content/projects/genderswap-fm/index.yml
+++ b/src/content/projects/genderswap-fm/index.yml
@@ -1,7 +1,10 @@
 title: Genderswap.fm
 description: A place to catalogue gender reversal in cover songs and all its queer implications. Because a Spotify playlist got a little too big. Andrea Lawlor called it "THE COOLEST thing I have EVER SEEN IN MY LIFE."
 datePublished: 2023-10-23
-url: https://genderswap.fm
 repo: evadecker/genderswap.fm
-img: "./genderswap-fm.png"
-imgAlt: "A collection of original and cover album art for different songs."
+img:
+  src: "./genderswap-fm.png"
+  alt: "A collection of original and cover album art for different songs."
+cta:
+  text: Visit the site
+  url: https://genderswap.fm

--- a/src/content/projects/hypersensitive/index.yml
+++ b/src/content/projects/hypersensitive/index.yml
@@ -1,6 +1,10 @@
 title: HYPERSENSITIVE
-description: A looping, generative meditation on overwhelm, synesthesia, and autism in a city.
+description: A looping, generative meditation on overwhelm, synesthesia, and autism.
 datePublished: 2024-02-11
-url: /hypersensitive
-video: "video/hypersensitive.mp4"
-videoPoster: "video/hypersensitive-poster.png"
+video:
+  src: "video/hypersensitive.mp4"
+  poster: "video/hypersensitive-poster.png"
+cta:
+  text: Visit the site
+  url: /hypersensitive
+repo: evadecker/eva.town/blob/main/src/pages/hypersensitive/index.astro

--- a/src/content/projects/journey-builder/index.yml
+++ b/src/content/projects/journey-builder/index.yml
@@ -1,5 +1,5 @@
 title: Journey Builder
-description: Internal marketing automation tool designed at Dropbox. Case study coming soon.
+description: Internal marketing automation tool designed at Dropbox.
 datePublished: 2017-06-01
-url: https://dropbox.com
-draft: true
+cta:
+  text: Case study coming soon

--- a/src/content/projects/namesake/index.yml
+++ b/src/content/projects/namesake/index.yml
@@ -1,4 +1,5 @@
 title: "Namesake"
-description: Design and build for a web app to assist trans people navigate the legal name change process. Case study coming soon.
+description: Design and build for a web app to assist trans people navigate the legal name change process.
 datePublished: 2024-02-15
-draft: true
+cta:
+  text: Case study coming soon

--- a/src/content/projects/perlin-pixels/index.yml
+++ b/src/content/projects/perlin-pixels/index.yml
@@ -1,4 +1,6 @@
 title: Perlin Pixels
 description: "Experiments with generative Perlin noise in P5.js. Refresh for different patterns and colors."
 datePublished: 2024-02-11
-url: /experiments/perlin
+cta:
+  text: View the experiment
+  url: /experiments/perlin

--- a/src/content/projects/swiftype/index.yml
+++ b/src/content/projects/swiftype/index.yml
@@ -1,0 +1,5 @@
+title: Swiftype
+description: Product and visual design from my time at Swiftype, a site search and enterprise search platform since acquired by Elastic Search.
+datePublished: 2016-03-01
+cta:
+  text: Case study coming soon

--- a/src/content/projects/wind-waker/index.yml
+++ b/src/content/projects/wind-waker/index.yml
@@ -1,4 +1,6 @@
 title: Wind Waker
 description: "Recreating pixel-fied water from The Legend of Zelda: The Wind Waker using P5.js."
 datePublished: 2024-02-11
-url: /experiments/wind-waker
+cta:
+  text: View the experiment
+  url: /experiments/wind-waker

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -44,19 +44,8 @@ const description = "Utilities and artworks for the web.";
                       ? -1
                       : 1
                   )
-                  .map(({ data }) => (
-                    <ProjectPreview
-                      title={data.title}
-                      description={data.description}
-                      datePublished={data.datePublished}
-                      img={data.img}
-                      imgAlt={data.imgAlt}
-                      url={data.url}
-                      repo={data.repo}
-                      disabled={data.draft}
-                      video={data.video}
-                      videoPoster={data.videoPoster}
-                    />
+                  .map((project) => (
+                    <ProjectPreview project={project} />
                   ))}
               </div>
             </section>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -80,5 +80,6 @@
 
   /* Font weights */
   --font-weight-normal: 400;
+  --font-weight-medium: 500;
   --font-weight-bold: 700;
 }


### PR DESCRIPTION
- Add call to action buttons for each project
- Reconfigure project scheme to group video props, image props, and CTA props as objects
- Extend `CollectionEntry` type instead of re-typing props for `ProjectPreview` component
- Add a Swiftype placeholder
- Support medium weight Franklin UTC

<img width="796" alt="image" src="https://github.com/evadecker/eva.town/assets/4117920/d93faf6d-c39f-4099-b8ec-e369ed73e6a2">
