### PR TITLE
fix: Fix typos, add website

### DIFF
--- a/src/components/ProjectInfo.astro
+++ b/src/components/ProjectInfo.astro
@@ -2,7 +2,6 @@
 import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 
-import { Icon } from "./Icon/Icon";
 import ProjectInfoBlock from "./ProjectInfoBlock.astro";
 
 interface Props {

--- a/src/components/ProjectInfo.astro
+++ b/src/components/ProjectInfo.astro
@@ -9,7 +9,7 @@ interface Props {
 }
 
 const { project } = Astro.props;
-const { timeline, roles, collaborators, tech, repo } = project.data;
+const { timeline, roles, collaborators, tech, website, repo } = project.data;
 ---
 
 <dl class="project-info">
@@ -45,6 +45,17 @@ const { timeline, roles, collaborators, tech, repo } = project.data;
           {tech.map((item) => (
             <li>{item}</li>
           ))}
+        </ul>
+      </ProjectInfoBlock>
+    )
+  }
+  {
+    website && (
+      <ProjectInfoBlock title="Website">
+        <ul>
+          <li>
+            <a href={website}>{website}</a>
+          </li>
         </ul>
       </ProjectInfoBlock>
     )

--- a/src/components/ProjectInfo.astro
+++ b/src/components/ProjectInfo.astro
@@ -2,6 +2,7 @@
 import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 
+import { Icon } from "./Icon/Icon";
 import ProjectInfoBlock from "./ProjectInfoBlock.astro";
 
 interface Props {
@@ -32,7 +33,7 @@ const { timeline, roles, collaborators, tech, website, repo } = project.data;
           {collaborators.map((collaborator) =>
             // Condense whitespace
             // prettier-ignore
-            <li><a class="collaborator" href={collaborator.url}><Image src={collaborator.img} alt={`A photo of ${collaborator.name}`} class="avatar" />{collaborator.name}</a></li>
+            <li><a class="collaborator" href={collaborator.url} target="_blank"><Image src={collaborator.img} alt={`A photo of ${collaborator.name}`} class="avatar" />{collaborator.name}</a></li>
           )}
         </ul>
       </ProjectInfoBlock>
@@ -54,7 +55,9 @@ const { timeline, roles, collaborators, tech, website, repo } = project.data;
       <ProjectInfoBlock title="Website">
         <ul>
           <li>
-            <a href={website}>{website}</a>
+            <a href={website} target="_blank">
+              {website}
+            </a>
           </li>
         </ul>
       </ProjectInfoBlock>
@@ -65,7 +68,9 @@ const { timeline, roles, collaborators, tech, website, repo } = project.data;
       <ProjectInfoBlock title="Source">
         <ul>
           <li>
-            <a href={`https://github.com/${repo}`}>View on Github</a>
+            <a href={`https://github.com/${repo}`} target="_blank">
+              View on Github
+            </a>
           </li>
         </ul>
       </ProjectInfoBlock>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -59,6 +59,7 @@ export const collections = {
             poster: z.string(),
           })
           .optional(),
+        website: z.string().url().optional(),
         repo: z.string().optional(), // GitHub repo, e.g. evadecker/america-my-face
         cta: z
           .object({

--- a/src/content/projects/2019/commonplace/index.mdx
+++ b/src/content/projects/2019/commonplace/index.mdx
@@ -168,7 +168,7 @@ With Cityblock's brand designer, [Minji](https://www.linkedin.com/in/minji-lee-b
 
 ### Color
 
-We considered colors use in Commons, prioritizing pure function, accessibility and contrast, relation to the brand, and coherence as a whole.
+When considering colors in Commons, we prioritized pure function, accessibility and contrast, relation to the brand, and coherence as a whole.
 
 I also examined the use of color in film to portray two separate settings—the hospital and the home.
 
@@ -228,7 +228,7 @@ Then began the long and steady process of building and replacing components one-
   </figcaption>
 </figure>
 
-Component work took place over the course of many months, alongside other feature work I was involved in. It took place largely independently, although I continued to collaborate with [Neves](https://www.nevesrodrigues.com/) for visual and interaction design feedback, researchers like [Amber](https://www.linkedin.com/in/amberhamptongreene/) and [Taylor](https://www.linkedin.com/in/taylorjmaynard/) for user insights, and engineers like [Brennan](https://www.zamiang.com/), [Aster](https://aster.fyi/), and [Craig](http://www.craigspaeth.com/), for code review.
+Component work took place over the course of many months, alongside other feature work I was involved in. It took place largely independently, although I continued to collaborate with [Neves](https://www.nevesrodrigues.com/) for visual and interaction design feedback, researchers like [Amber](https://www.linkedin.com/in/amberhamptongreene/) and [Taylor](https://www.linkedin.com/in/taylorjmaynard/) for user insights, and engineers like [Brennan](https://www.zamiang.com/), [Aster](https://aster.fyi/), and [Craig](http://www.craigspaeth.com/) for code review.
 
 We chose an incremental approach—rather than building and shipping an entirely new design system all at once—in order to maintain forward momentum, bug test along the way, and enable new features to be built with new components as quickly as possible.
 

--- a/src/content/projects/2022/boundaries-map/index.mdx
+++ b/src/content/projects/2022/boundaries-map/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: NYC Boundaries Map
-description: View administrative boundaries in New York City—school districts, sanitation districts, police precincts, and more.
+description: Mapping New York's civic boundaries.
 slug: boundaries-map
 roles:
   - Research
@@ -15,6 +15,7 @@ tech:
   - Mapbox
   - Svelte
   - Tailwind
+website: https://boundaries.beta.nyc
 repo: betanyc/nyc-boundaries
 video:
   src: video/boundaries-map.mp4
@@ -45,7 +46,7 @@ BetaNYC maintains an open source web app called [NYC Boundaries Map](https://bou
 
 The Boundaries Map helps answer questions like, "which school districts does this community board serve?", "which sanitation district do I contact about the trash at 2nd Avenue and East 14th Street?", and "what police precinct am I in right now?"
 
-However, the map was not pleasant to use.
+The map was not pleasant to use.
 
 <figure>
   ![The NYC Boundaries Map as of June 2022.](./boundaries-map-initial.png)
@@ -59,9 +60,9 @@ Working together with [Zhi](https://github.com/zhik), we noted several usability
 
 1. Toggling on more than two districts quickly made the map illegible.
 2. Boundaries on the map itself were not interactive.
-3. The map's implementation in [Leaflet](https://leafletjs.com/) resulted in rasterized borders and labels, which looked blurry on high-DPI screens.
-4. The map required frequent manual zooming and panning, since it did not adapt automatically to queries.
-5. Viewing overlaps required a complex sequence of "querying" boundaries by selecting an administrative region and then selecting which district to intersect with, and the query itself was slow to execute.
+3. The map's implementation in [Leaflet](https://leafletjs.com/) resulted in rasterized borders and labels, which looked blurry on HiDPI screens.
+4. Viewing overlaps required a complex sequence of "querying" boundaries by selecting an administrative region and then selecting which district to intersect with, and the query itself was slow to execute.
+5. The map required frequent manual zooming and panning, since it did not adapt automatically to queries.
 6. Searching for an address required pre-selecting a borough.
 7. Viewing additional metadata about a district required leaving the app and searching Google.
 8. The app was desktop-only.
@@ -84,7 +85,7 @@ With a solid list of usability tickets to address, I got to work sketching ideas
 
 Without delay, we dove into code. After quick exploration with various frontend libraries, I installed [Svelte](https://svelte.dev/) and [Tailwind](https://tailwindcss.com/), which would allow us to build more advanced functionality more easily. We moved from Leaflet to [Mapbox](https://www.mapbox.com/) since it offered us exciting opportunities to interact with the map directly.
 
-Additionally, we scheduled video calls with some frequent users of the Boundaries Map in order to better understand how they were using the tool and what could be improved. We shared our work-in-progress prototype for feedback. The participants were excited to be a part of the process and helped validate assumptions we had made.
+We scheduled video calls with some frequent users of the Boundaries Map in order to better understand how they were using the tool and what could be improved. We shared our work-in-progress prototype for feedback. The participants were excited to be a part of the process and helped validate assumptions we had made.
 
 ## Outcomes
 
@@ -108,7 +109,7 @@ After a few short weeks, we announced the updated app.
   </figcaption>
 </figure>
 
-The new map automatically zooms and pans to the selected boundaries, displays boundary overlaps on hover, allows single-click filtering by clicking any boundary, and supports mobile viewing. It also links out to relevant webpages for a district when available, so you can quickly jump to get additional info about a specific community bound, city council district, and more. We also introduced the ability to share a filtered view via URL, and export overlaps to JSON for analysis in other tools.
+The new map automatically zooms and pans to the selected boundary. It displays boundary overlaps on hover, allows single-click filtering by clicking any boundary, and supports mobile viewing. It links to the relevant webpage for a district when available, so users can find things like phone numbers for city council members. And it now allows users to share URLs for filtered views, and export overlap data to JSON for analysis in other tools.
 
 [Read the announcement](https://beta.nyc/2022/09/07/summer-associates-wrap-up/) or [explore boundaries](https://boundaries.beta.nyc/?).
 
@@ -116,6 +117,6 @@ The new map automatically zooms and pans to the selected boundaries, displays bo
 
 I had never worked with mapping technology before, so it was fun to learn about how to wield geospatial data using Mapbox. (Huge thanks to [Zhi](https://github.com/zhik) sharing his knowledge of GeoJSON and Shapefiles!) Svelte and Tailwind were also new frameworks for me, and this project helped me get more familiar with their capabilities.
 
-With extra time, I'd explore how to improve mobile navigation, since touchscreens can't support the same hover interactions as desktop. I'd also explore whether it's worth introducing color to the base map to more clearly communicate the locations of parks, water, and other regions. (Boundaries Map is [open source](https://github.com/BetaNYC/nyc-boundaries), so maybe I'll get to these one day! Or maybe you can, dear reader.)
+With extra time, I'd explore how to improve mobile navigation, since touchscreens can't support the same hover interactions as desktop. I'd also explore whether it's worth introducing color to the base map to more clearly communicate the locations of parks, water, and other regions. (Boundaries Map is [open source](https://github.com/BetaNYC/nyc-boundaries), so maybe I'll get to these one day! Or maybe you, my reader, can make contributions of your own.)
 
 BetaNYC introduced me to the city's vast library of [open data](https://opendata.cityofnewyork.us/), and I've continued to think about other possibilities for design and technology to surface public data for good.

--- a/src/content/projects/2023/genderswap/index.md
+++ b/src/content/projects/2023/genderswap/index.md
@@ -16,6 +16,7 @@ tech:
   - Supabase
   - Spotify Web API
   - TypeScript
+website: https://genderswap.fm
 repo: evadecker/genderswap.fm
 img:
   src: "./genderswap-fm.png"

--- a/src/layouts/ProseLayout.astro
+++ b/src/layouts/ProseLayout.astro
@@ -2,6 +2,7 @@
 import "../styles/prose.css";
 
 import PageHeader from "../components/PageHeader.astro";
+import { smartquotes } from "../helpers/helpers";
 import BaseLayout from "./BaseLayout.astro";
 
 interface Props {
@@ -29,7 +30,7 @@ const {
 
 <BaseLayout
   title={title}
-  description={description}
+  description={smartquotes(description)}
   includeFooter
   padBottom
   ogImage={ogImage}
@@ -38,7 +39,7 @@ const {
   <article itemscope itemtype="https://schema.org/BlogPosting">
     <PageHeader
       title={title}
-      description={description}
+      description={smartquotes(description)}
       datePublished={datePublished}
       dateModified={dateModified}
       img={img}


### PR DESCRIPTION
- Fix typos and improve copy for Boundaries Map and Commonplace case studies
- Add `website` structured field for projects
- Use smartquotes for ProseLayout description and header
- Open project links in new tab