### PR TITLE
feat: Update project descriptions and card previews

### DIFF
--- a/src/components/ProjectInfoBlock.astro
+++ b/src/components/ProjectInfoBlock.astro
@@ -19,7 +19,7 @@ const { title } = Astro.props;
   .project-info-block {
     display: flex;
     flex-direction: row;
-    gap: var(--space-2xs);
+    column-gap: var(--space-2xs);
 
     @media (width < 600px) {
       flex-direction: column;

--- a/src/components/ProjectPreview.astro
+++ b/src/components/ProjectPreview.astro
@@ -3,7 +3,6 @@ import { Image } from "astro:assets";
 import type { CollectionEntry } from "astro:content";
 
 import { smartquotes } from "../helpers/helpers";
-import { Icon } from "./Icon/Icon";
 
 interface Props {
   project: CollectionEntry<"projects">;
@@ -11,10 +10,10 @@ interface Props {
 
 const { project } = Astro.props;
 
-const { title, description, repo, img, video, cta, roles } = project.data;
+const { title, description, img, video, url, roles } = project.data;
 ---
 
-<div class="project">
+<div class:list={["project", { draft: url === undefined }]}>
   {
     (img ?? video) && (
       <div class="media">
@@ -31,6 +30,7 @@ const { title, description, repo, img, video, cta, roles } = project.data;
             <source src={video.src} type="video/mp4" />
           </video>
         )}
+        {url === undefined && <div class="coming-soon">Coming Soon</div>}
       </div>
     )
   }
@@ -47,32 +47,12 @@ const { title, description, repo, img, video, cta, roles } = project.data;
       </div>
     </div>
     {
-      (cta ?? repo) && (
-        <footer>
-          {cta && (
-            <a
-              class:list={[
-                "button",
-                "cta",
-                { disabled: cta.url === undefined },
-              ]}
-              href={cta.url}
-              aria-disabled={cta.url === undefined}
-            >
-              {cta.text}
-            </a>
-          )}
-          {repo && (
-            <a
-              class="button repo"
-              href={`https://github.com/${repo}`}
-              target="_blank"
-              title="View source code on GitHub"
-            >
-              <Icon icon="github" size="20" />
-            </a>
-          )}
-        </footer>
+      url && (
+        <a
+          class:list={["link", { disabled: url === undefined }]}
+          href={url}
+          title="Read the case study"
+        />
       )
     }
   </div>
@@ -83,14 +63,43 @@ const { title, description, repo, img, video, cta, roles } = project.data;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--space-m);
-  }
+    position: relative;
+    overflow: hidden;
+    background-color: var(--gray-2);
+    border-radius: var(--radius-m);
+    transition: background-color 0.2s ease-in-out;
 
-  .details {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-m);
-    width: 100%;
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border: 1px solid var(--gray-a6);
+      border-radius: var(--radius-m);
+      pointer-events: none;
+      transition: border-color 0.2s ease-in-out;
+    }
+
+    .details {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-m);
+      padding: var(--space-l);
+      width: 100%;
+    }
+
+    &.draft {
+      .media *:not(.coming-soon),
+      .details {
+        opacity: 0.4;
+        pointer-events: none;
+      }
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      &:not(.draft):hover {
+        background-color: var(--gray-3);
+      }
+    }
   }
 
   .details-text {
@@ -126,7 +135,7 @@ const { title, description, repo, img, video, cta, roles } = project.data;
     color: var(--gray-11);
 
     .tag {
-      background-color: var(--gray-3);
+      background-color: var(--gray-4);
       padding-inline: var(--space-2xs);
       border-radius: var(--radius-xs);
     }
@@ -140,22 +149,35 @@ const { title, description, repo, img, video, cta, roles } = project.data;
   }
 
   .media {
-    background-color: var(--gray-3);
     width: 100%;
     max-width: 100%;
-    border-radius: var(--radius-s);
-    overflow: hidden;
     line-height: 0;
     position: relative;
 
     &::after {
       content: "";
+      height: 1px;
+      left: 0;
+      right: 0;
+      bottom: 0;
       position: absolute;
-      inset: 0;
-      border: 1px solid var(--gray-a3);
-      border-radius: var(--radius-s);
-      pointer-events: none;
+      background-color: var(--gray-a4);
+      transition: background-color 0.2s ease-in-out;
     }
+  }
+
+  .coming-soon {
+    position: absolute;
+    font-size: var(--step-1);
+    line-height: 1;
+    background: var(--gray-12);
+    color: var(--gray-1);
+    padding: var(--space-xs);
+    border-radius: var(--radius-s);
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(-12deg);
+    z-index: 1;
   }
 
   h3 {
@@ -166,56 +188,8 @@ const { title, description, repo, img, video, cta, roles } = project.data;
     line-height: 1.3;
   }
 
-  footer {
-    display: flex;
-    flex-flow: row;
-    width: 100%;
-    gap: var(--space-s);
-  }
-
-  .button {
-    cursor: pointer;
-    font-weight: var(--font-weight-medium);
-    border: 1px solid var(--gray-6);
-    color: var(--gray-11);
-    padding-inline: var(--space-m);
-    padding-block: var(--space-2xs);
-    border-radius: var(--radius-s);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-2xs);
-    border-color: var(--gray-6);
-
-    &.disabled {
-      opacity: 0.5;
-    }
-
-    &.cta {
-      flex: 1;
-    }
-  }
-
-  :global(.dark) .button {
-    background-color: var(--gray-3);
-    border-color: var(--gray-a3);
-  }
-
-  :global(.transitioning) .button {
-    transition:
-      color 0.2s ease-in-out,
-      background-color 0.2s ease-in-out,
-      border-color 0.2s ease-in-out;
-  }
-
-  .button:not(.disabled):hover {
-    background-color: white;
-    border-color: var(--gray-7);
-    color: var(--gray-12);
-  }
-
-  :global(.dark) .button:not(.disabled):hover {
-    background-color: var(--gray-4);
-    border-color: var(--gray-6);
+  .link {
+    position: absolute;
+    inset: 0;
   }
 </style>

--- a/src/components/ProjectPreview.astro
+++ b/src/components/ProjectPreview.astro
@@ -14,6 +14,7 @@ const { title, description, img, video, url, roles } = project.data;
 ---
 
 <div class:list={["project", { draft: url === undefined }]}>
+  {url === undefined && <div class="coming-soon">Coming Soon</div>}
   {
     (img ?? video) && (
       <div class="media">
@@ -30,7 +31,6 @@ const { title, description, img, video, url, roles } = project.data;
             <source src={video.src} type="video/mp4" />
           </video>
         )}
-        {url === undefined && <div class="coming-soon">Coming Soon</div>}
       </div>
     )
   }
@@ -64,7 +64,6 @@ const { title, description, img, video, url, roles } = project.data;
     flex-direction: column;
     align-items: flex-start;
     position: relative;
-    overflow: hidden;
     background-color: var(--gray-2);
     border-radius: var(--radius-m);
     transition: background-color 0.2s ease-in-out;
@@ -153,6 +152,9 @@ const { title, description, img, video, url, roles } = project.data;
     max-width: 100%;
     line-height: 0;
     position: relative;
+    border-top-left-radius: var(--radius-m);
+    border-top-right-radius: var(--radius-m);
+    overflow: hidden;
 
     &::after {
       content: "";
@@ -168,15 +170,16 @@ const { title, description, img, video, url, roles } = project.data;
 
   .coming-soon {
     position: absolute;
+    font-weight: var(--font-weight-medium);
     font-size: var(--step-1);
     line-height: 1;
     background: var(--gray-12);
     color: var(--gray-1);
     padding: var(--space-xs);
     border-radius: var(--radius-s);
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%) rotate(-12deg);
+    top: var(--space-2xs);
+    left: calc(-1 * var(--space-m));
+    transform: rotate(-12deg);
     z-index: 1;
     box-shadow:
       0 0.9px 1.4px rgb(0 0 0 / 0.6%),

--- a/src/components/ProjectPreview.astro
+++ b/src/components/ProjectPreview.astro
@@ -178,6 +178,11 @@ const { title, description, img, video, url, roles } = project.data;
     left: 50%;
     transform: translate(-50%, -50%) rotate(-12deg);
     z-index: 1;
+    box-shadow:
+      0 0.9px 1.4px rgb(0 0 0 / 0.6%),
+      0 2.5px 3.8px rgb(0 0 0 / 1.6%),
+      0 6px 9px rgb(0 0 0 / 3.1%),
+      0 20px 30px rgb(0 0 0 / 7%);
   }
 
   h3 {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -61,12 +61,7 @@ export const collections = {
           .optional(),
         website: z.string().url().optional(),
         repo: z.string().optional(), // GitHub repo, e.g. evadecker/america-my-face
-        cta: z
-          .object({
-            text: z.string(),
-            url: z.string().optional(), // If no URL is set, button will be disabled
-          })
-          .optional(),
+        url: z.string().optional(), // If no case study URL, project will be disabled
         ogImage: image().optional(),
       }),
   }),

--- a/src/content/projects/2015/swiftype/index.md
+++ b/src/content/projects/2015/swiftype/index.md
@@ -1,6 +1,6 @@
 ---
 title: Swiftype
-description: Swiftype is a site search and enterprise search platform. I created illustrations and iconography and helped redesign their marketing site and product dashboard.
+description: Redesigning a product dashboard for simpler site search management.
 slug: swiftype
 roles: 
   - Product Design
@@ -18,8 +18,6 @@ tech:
 video:
   src: "video/swiftype.mp4"
   poster: "video/swiftype.png"
-cta:
-  text: Case study coming soon
 ---
 
 ## Case study coming soon.

--- a/src/content/projects/2016/journey-builder/index.md
+++ b/src/content/projects/2016/journey-builder/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Dropbox Journey Builder"
-description: I helped the Growth Platform team at Dropbox design and build a better in-house solution for marketing automation, unifying notifications across multiple channels under a configurable flowchart tool.
+description: Building an in-house solution for marketing automation.
 slug: journey-builder
 roles: 
   - Research
@@ -26,8 +26,6 @@ tech:
 img:
   src: ./journey-builder.png
   alt: Analytics and a flowchart UI for a marketing automation tool.
-cta:
-  text: Case study coming soon
 ---
 
 ## Case study coming soon.

--- a/src/content/projects/2017/dropbox-showcase/index.md
+++ b/src/content/projects/2017/dropbox-showcase/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dropbox Showcase
-description: I contributed design and iconography for Dropbox Showcase, a (now defunct) tool to help creatives show their work to clients and receive feedback.
+description: Helping creatives show their work to clients and receive feedback.
 slug: dropbox-showcase
 roles:
   - Product Design
@@ -19,8 +19,6 @@ collaborators:
 img:
   src: ./dropbox-showcase.png
   alt: A preview of creating a collection within Dropbox Showcase.
-cta:
-  text: Case study coming soon
 ---
 
 ## Case study coming soon.

--- a/src/content/projects/2018/dropbox-comments/index.md
+++ b/src/content/projects/2018/dropbox-comments/index.md
@@ -1,6 +1,6 @@
 ---
 title: Dropbox File Comments
-description: I helped design and ship improvements to Dropbox file comments on web, including annotations and time-coded commenting on audiovisual files.
+description: Introducing time-coded commenting on audiovisual files.
 slug: dropbox-comments
 roles:
   - Research
@@ -13,8 +13,6 @@ timeline: January 2018 – August 2018
 img:
   src: ./dropbox-comments.png
   alt: A preview of commenting UI used on Dropbox web.
-cta:
-  text: Case study coming soon
 ---
 
 ## Case study coming soon.

--- a/src/content/projects/2019/commonplace/index.mdx
+++ b/src/content/projects/2019/commonplace/index.mdx
@@ -45,9 +45,7 @@ tech:
 img:
   src: ./commonplace.png
   alt: A collection of Commonplace components represented in Figma and in code.
-cta:
-  text: Read the case study
-  url: /projects/commonplace
+url: /projects/commonplace
 ogImage: ./commonplace-og.png
 ---
 

--- a/src/content/projects/2022/boundaries-map/index.mdx
+++ b/src/content/projects/2022/boundaries-map/index.mdx
@@ -20,9 +20,7 @@ repo: betanyc/nyc-boundaries
 video:
   src: video/boundaries-map.mp4
   poster: video/boundaries-map-poster.png
-cta:
-  text: Read the case study
-  url: /projects/boundaries-map
+url: /projects/boundaries-map
 ogImage: ./boundaries-map-og.png
 ---
 

--- a/src/content/projects/2023/genderswap/index.md
+++ b/src/content/projects/2023/genderswap/index.md
@@ -1,6 +1,6 @@
 ---
 title: Genderswap.fm
-description: A catalogue of gender reversal in cover songs and all its queer implications. Because a Spotify playlist got a little too big.
+description: Cataloguing gender reversal in cover songs.
 slug: genderswap
 roles: 
   - Product Design
@@ -21,9 +21,6 @@ repo: evadecker/genderswap.fm
 img:
   src: "./genderswap-fm.png"
   alt: "A collection of original and cover album art for different songs."
-cta:
-  text: Discover music
-  url: https://genderswap.fm
 ---
 
 ## Case study coming soon.

--- a/src/content/projects/2024/namesake/index.md
+++ b/src/content/projects/2024/namesake/index.md
@@ -1,6 +1,6 @@
 ---
 title: Namesake
-description: Work-in-progress design and build for a web app to help trans people navigate the (often byzantine) legal name change process.
+description: Streamlining the legal name change process for trans people in the U.S.
 slug: namesake
 roles:
   - Research
@@ -20,8 +20,6 @@ tech:
 img:
   src: ./namesake.png
   alt: A collection of components for Namesake.
-cta:
-  text: Coming soon
 ---
 
 ## Case study coming soon.

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -44,7 +44,7 @@ const description = "A collection of tools I've helped design and build.";
   .projects {
     display: flex;
     flex-direction: column;
-    gap: var(--space-3xl);
+    gap: var(--space-xl);
   }
 
   .side-projects {


### PR DESCRIPTION
- Condense project descriptions, use same format of starting with an -ing verb
- Remove row spacing from project info cards
- Remove buttons and CTA text from project previews, make entire card clickable
- Add "coming soon" banner for case studies not yet written

<img width="496" alt="image" src="https://github.com/evadecker/eva.town/assets/4117920/9f0c0e55-08c7-4368-ad9e-39bcc95c8538">