### PR TITLE
fix: Position new stickers within the viewport

### DIFF
--- a/src/components/Stickers/Sticker.tsx
+++ b/src/components/Stickers/Sticker.tsx
@@ -124,10 +124,10 @@ export const Sticker = ({ variant }: StickerProps) => {
   const $topZIndex = useStore(topZIndex);
   const [zIndex, setZIndex] = useState($topZIndex);
   const [x, setX] = useState(
-    getRandomValueBetween(0, document.body.clientWidth - BUFFER)
+    getRandomValueBetween(0, window.innerWidth - BUFFER)
   );
   const [y, setY] = useState(
-    getRandomValueBetween(0, document.body.clientHeight - BUFFER)
+    getRandomValueBetween(0, window.innerHeight - BUFFER)
   );
   const [rotate] = useState(getRandomValueBetween(-10, 10));
 


### PR DESCRIPTION
- Stickers were appearing beneath the fold occasionally leading to the appearance of a faulty trigger button