### PR TITLE
fix: Post timestamps

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,4 +1,6 @@
 ---
+import dayjs from "dayjs";
+
 import Center from "./Center.astro";
 import { Icon } from "./Icon/Icon";
 import Picture from "./Picture.astro";
@@ -15,6 +17,8 @@ interface Props {
 
 const { title, description, img, imgAlt, datePublished, dateModified } =
   Astro.props;
+
+const isModifiedSameDay = dayjs(datePublished).isSame(dateModified, "day");
 ---
 
 <header class="page-header">
@@ -38,7 +42,7 @@ const { title, description, img, imgAlt, datePublished, dateModified } =
           </div>
           <span>
             Planted <RelativeDate date={datePublished} client:load />
-            {dateModified && (
+            {dateModified && !isModifiedSameDay && (
               <span class="tended">
                 + tended <RelativeDate date={dateModified} client:load />
               </span>

--- a/src/components/PostLink.astro
+++ b/src/components/PostLink.astro
@@ -15,7 +15,7 @@ const { url, title, description, datePublished } = Astro.props;
   {
     datePublished && (
       <div class="date">
-        <RelativeDate date={datePublished} />
+        <RelativeDate date={datePublished} client:load />
       </div>
     )
   }


### PR DESCRIPTION
- Add `client: load` to update post timestamp in list within `/garden`
- Do not show the date tended if it's the same date as the date published