### PR TITLE
fix: Remove Vercel 200 from CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,8 +22,12 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm i
+      - name: Install Playwright
+        run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npx playwright test --project="Google Chrome"
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,15 +22,8 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm i
-      - name: Wait for Vercel preview
-        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
-        id: waitFor200
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Playwright tests
         run: npx playwright test --project="Google Chrome"
-        env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitFor200.outputs.url || 'https://eva.town' }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: pnpm i
       - name: Install Playwright
-        run: pnpm exec playwright install
+        run: pnpm exec playwright install chromium
       - name: Run Playwright tests
         run: pnpm test
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,11 +23,11 @@ jobs:
       - name: Install dependencies
         run: pnpm i
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install-deps chromium
+      - name: Start dev server
+        run: pnpm dev
       - name: Run Playwright tests
         run: npx playwright test --project="Google Chrome"
-        env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,11 +23,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i
       - name: Install Playwright
-        run: npx playwright install-deps chromium
-      - name: Start dev server
-        run: pnpm dev
+        run: pnpm exec playwright install
       - name: Run Playwright tests
-        run: npx playwright test --project="Google Chrome"
+        run: pnpm test
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,75 +1,24 @@
 import { defineConfig, devices } from "@playwright/test";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
-
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  workers: process.env.CI ? 1 : undefined, // Opt out of parallel tests on CI.
   reporter: "html",
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL || "http://localhost:4321",
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL ?? "http://localhost:4321",
     trace: "on-first-retry",
   },
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
-
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
-
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
-
-    /* Test against mobile viewports. */
-    {
-      name: "Mobile Chrome",
-      use: { ...devices["Pixel 5"] },
-    },
-    {
-      name: "Mobile Safari",
-      use: { ...devices["iPhone 12"] },
-    },
-
-    /* Test against branded browsers. */
-    {
-      name: "Microsoft Edge",
-      use: { ...devices["Desktop Edge"], channel: "msedge" },
-    },
-    {
-      name: "Google Chrome",
-      use: { ...devices["Desktop Chrome"], channel: "chrome" },
-    },
   ],
-
-  /* Run your local dev server before starting the tests */
   webServer: {
-    command: "pnpm start",
+    command: "pnpm dev",
+    url: "http://localhost:4321",
     reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
- Waiting for Vercel during tests was causing test flakiness due to increased build times; this tests Playwright locally instead
- Resolves #378 

Playwright tests now succeed in ~37s where before they took around 1 minute on average