### PR TITLE
fix: Update Lychee CI, remove base URL

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,18 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore Lychee cache
-        uses: actions/cache@v3
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
-          restore-keys: cache-lychee-
-
       - name: Run Lychee
         uses: lycheeverse/lychee-action@v1
         with:
           args: "--no-progress --config .lychee.toml ."
-          fail: true
 
       - name: Create Issue From File
         if: env.lychee_exit_code != 0
@@ -32,4 +24,4 @@ jobs:
         with:
           title: Link Checker Report
           content-filepath: ./lychee/out.md
-          labels: report, automated issue
+          labels: automated

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -31,9 +31,6 @@ scheme = ["https"]
 # When links are available using HTTPS, treat HTTP links as errors.
 require_https = true
 
-# Base URL or website root directory to check relative URLs.
-base = "https://eva.town"
-
 #############################  Exclusions  ##########################
 
 # Exclude URLs and mail addresses from checking (supports regex).


### PR DESCRIPTION
- Don't fail CI test
- Remove base URL to accommodate relative paths
- Remove caching
- Simplify labeling