### PR TITLE
fix: Relocate and rerun Fathom

### DIFF
--- a/src/layouts/UnstyledBase.astro
+++ b/src/layouts/UnstyledBase.astro
@@ -112,13 +112,14 @@ const pageTitle = Astro.url.pathname === "/" ? title : `${title} · Eva Decker`;
     <ViewTransitions />
     <SpeedInsights />
     <LoadingIndicator color="var(--blue-9)" height="3px" threshold={600} />
+  </head>
+  <body>
+    <slot />
     <script
       src="https://cdn.usefathom.com/script.js"
       data-site="WKFTECUZ"
       defer
-      is:inline></script>
-  </head>
-  <body>
-    <slot />
+      is:inline
+      data-astro-rerun></script>
   </body>
 </html>


### PR DESCRIPTION
I think the Fathom script in the `head` was blocking render and causing a flash of unstyled content on page transition; this moves the script to the end of the `body` and adds `data-astro-rerun` to ensure that the script still functions after view transition.