### PR TITLE
chore: Ignore markdown paths but run CI for everything else

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,30 +3,10 @@ name: CI
 on:
   push:
     branches: main
-    paths:
-      [
-        "src/components/**",
-        "src/helpers/**",
-        "src/layouts/**",
-        "src/pages/**",
-        "src/stores/**",
-        "playwright.config.ts",
-        "astro.config.mjs",
-        ".htmlvalidate.json",
-      ]
+    paths-ignore: ["**/*.md", "**/*.mdx"]
   pull_request:
     branches: main
-    paths:
-      [
-        "src/components/**",
-        "src/helpers/**",
-        "src/layouts/**",
-        "src/pages/**",
-        "src/stores/**",
-        "playwright.config.ts",
-        "astro.config.mjs",
-        ".htmlvalidate.json",
-      ]
+    paths-ignore: ["**/*.md", "**/*.mdx"]
 
 jobs:
   test:


### PR DESCRIPTION
- CI was not re-running when Dependabot would update dependencies; need to reconfigure CI path inclusion logic to make sure deps updates are good to merge