### PR TITLE
fix: Don't fade out last project

### DIFF
--- a/src/components/ProjectPreview.astro
+++ b/src/components/ProjectPreview.astro
@@ -72,9 +72,11 @@ const { Content } = await render();
     padding-top: var(--space-2xl);
 
     @supports (animation-timeline: view()) {
-      animation: fadeOut linear forwards;
-      animation-range: cover 70% cover 95%;
-      animation-timeline: view();
+      &:not(:last-of-type) {
+        animation: fadeOut linear forwards;
+        animation-range: cover 70% cover 95%;
+        animation-timeline: view();
+      }
     }
   }
 


### PR DESCRIPTION
Prevent view transition fadeout for last project in list on the homepage