### PR TITLE
Exclude Vimeo from link checking

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -34,7 +34,7 @@ require_https = true
 #############################  Exclusions  ##########################
 
 # Exclude URLs and mail addresses from checking (supports regex).
-exclude = ['^https://www\.linkedin\.com', '^https://bookshop\.org']
+exclude = ['^https://www\.linkedin\.com', '^https://bookshop\.org', '^https://vimeo\.com']
 
 # Check mail addresses
 include_mail = true


### PR DESCRIPTION
Vimeo returns a 403 Forbidden error when Lychee checks it; exclude Vimeo links.