### PR TITLE
fix: Use server rendering for Netlify

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,7 +12,7 @@ import { autolinkConfig } from "./plugins/rehype-autolink-config";
 
 export default defineConfig({
   site: "https://eva.town",
-  output: "hybrid",
+  output: "server",
   prefetch: true,
   integrations: [
     react(),


### PR DESCRIPTION
Server-rendered pages were 404ing with `output: hybrid`.