### PR TITLE
content: Remove videos and work from index

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,19 +1,7 @@
 ---
-import { getCollection } from "astro:content";
-
 import Center from "../components/Center.astro";
-import ProjectPreview from "../components/ProjectPreview.astro";
 import Synth from "../components/Synth/Synth.astro";
 import BaseLayout from "../layouts/BaseLayout.astro";
-
-const work = await getCollection("work");
-
-// Sort by year subdirectory
-work.sort((a, b) =>
-  Number.parseInt(a.id.substring(0, 4)) > Number.parseInt(b.id.substring(0, 4))
-    ? -1
-    : 1,
-);
 ---
 
 <BaseLayout
@@ -36,20 +24,6 @@ work.sort((a, b) =>
       <div class="synth">
         <Synth />
       </div>
-      <div class="continue">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          width="40px"
-          fill="currentColor"
-          ><path
-            d="M11.9999 13.1714L16.9497 8.22168L18.3639 9.63589L11.9999 15.9999L5.63599 9.63589L7.0502 8.22168L11.9999 13.1714Z"
-          ></path></svg
-        >
-      </div>
-    </section>
-    <section class="work">
-      {work.map((project) => <ProjectPreview project={project} />)}
     </section>
   </Center>
 </BaseLayout>
@@ -109,23 +83,7 @@ work.sort((a, b) =>
     display: flex;
     flex-direction: column;
     gap: var(--space-3xl);
-    min-height: calc(100svh - var(--space-3xl) * 1.8);
-  }
-
-  .continue {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: auto;
-    color: var(--gray-10);
-
-    @supports (animation-timeline: view()) {
-      animation-name: fadeOut;
-      animation-timing-function: linear;
-      animation-fill-mode: both;
-      animation-timeline: view();
-      animation-range: contain 50% contain 80%;
-    }
+    padding-block-end: var(--space-3xl);
   }
 
   @keyframes rotate {


### PR DESCRIPTION
Want to move away from "portfolio-as-resume" and more toward "here are all the little things I enjoy and have created".

Removing work history and video embeds from homepage. Should come with a nice perf boost since we don't load videos any more.