### PR TITLE
fix: Allow shooing Sams multiple times, improve shake animation

### DIFF
--- a/src/components/Stickers/Stickers.tsx
+++ b/src/components/Stickers/Stickers.tsx
@@ -1,23 +1,22 @@
 import { useStore } from "@nanostores/react";
-import { AnimatePresence, motion } from "framer-motion";
+import classNames from "classnames";
+import { AnimatePresence } from "framer-motion";
 import { nanoid } from "nanoid";
 import { useEffect, useState } from "react";
-
 import { clearSams, numSams } from "../../stores/sam";
 import { Sticker, type StickerProps } from "./Sticker";
 
 export const Stickers = () => {
   const [stickers, setStickers] = useState<StickerProps[]>([]);
   const [showShoo, setShowShoo] = useState(false);
+  const [exiting, setExiting] = useState(false);
   const $numSams = useStore(numSams);
 
   const addSticker = () => {
-    const getNewSticker = () => {
-      return {
-        id: nanoid(),
-        variant: $numSams,
-      };
-    };
+    const getNewSticker = () => ({
+      id: nanoid(),
+      variant: $numSams,
+    });
     setStickers((prev) => [...prev, getNewSticker()]);
   };
 
@@ -34,6 +33,14 @@ export const Stickers = () => {
     }
   }, [$numSams, stickers]);
 
+  const handleShoo = () => {
+    setExiting(true);
+    clearSams();
+    setTimeout(() => {
+      setExiting(false);
+    }, 300);
+  };
+
   return (
     <div className="stickers" style={{ viewTransitionName: "stickers" }}>
       <AnimatePresence>
@@ -42,25 +49,16 @@ export const Stickers = () => {
         ))}
         {showShoo && (
           <div className="shoo-wrapper">
-            <motion.button
+            <button
               data-sam-shoo
+              onClick={handleShoo}
+              className={classNames({
+                exiting,
+              })}
               type="button"
-              onClick={clearSams}
-              initial={{ y: 50 }}
-              animate={{ y: 0 }}
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 1 }}
-              exit={{
-                cursor: "default",
-                scale: [
-                  1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 1.1, 0.8,
-                ],
-                x: [0, -8, -12, -12, 16, -36, 80, -48, 16, -8, 2, 0],
-                opacity: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0],
-              }}
             >
               Shoo Sam
-            </motion.button>
+            </button>
           </div>
         )}
       </AnimatePresence>

--- a/src/components/Stickers/stickers.css
+++ b/src/components/Stickers/stickers.css
@@ -59,6 +59,45 @@
   padding: var(--space-xl);
 }
 
+@keyframes shoo {
+  0% {
+    transform: rotate(0deg);
+    opacity: 1;
+  }
+  15%,
+  30% {
+    transform: rotate(-7deg);
+    opacity: 1;
+  }
+  45% {
+    transform: rotate(8deg);
+  }
+  60% {
+    transform: rotate(-9deg);
+  }
+  75% {
+    transform: rotate(10deg);
+  }
+  90% {
+    transform: rotate(-9deg);
+  }
+  100% {
+    transform: rotate(8deg);
+    opacity: 0;
+  }
+}
+
+@keyframes slideUp {
+  0% {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
 [data-sam-shoo] {
   background-color: var(--gray-12);
   border: none;
@@ -66,8 +105,22 @@
   border-radius: var(--radius-full);
   padding: var(--space-2xs) var(--space-m);
   font-weight: var(--font-weight-medium);
-  transition: opacity 0.2s ease;
+  transition: scale 0.2s ease;
+  transform-origin: 50% 150%;
   cursor: pointer;
   pointer-events: auto;
   box-shadow: var(--shadow-m);
+  animation: slideUp 0.3s ease both;
+}
+
+[data-sam-shoo]:hover {
+  scale: 1.15;
+}
+
+[data-sam-shoo]:active {
+  transform: scale(1.1) rotate(10deg);
+}
+
+[data-sam-shoo].exiting {
+  animation: shoo 0.5s ease-in both;
 }


### PR DESCRIPTION
Use CSS for shake animation instead of Framer motion to improve performance. Allow shooing Sam repeatedly by clearing classes after shoo.

Fixes #544 