### PR TITLE
fix(perf): Paginate guestbook and fix infinite stickers re-rendering bug

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 
 // Icons sourced from https://remixicon.com
 export type IconType =
+  | "arrowLeft"
   | "arrowRight"
   | "code"
   | "download"
@@ -46,6 +47,10 @@ export interface IconProps {
 }
 
 const iconData: Record<IconType, { line: string; filled: string }> = {
+  arrowLeft: {
+    line: "M7.82843 10.9999H20V12.9999H7.82843L13.1924 18.3638L11.7782 19.778L4 11.9999L11.7782 4.22168L13.1924 5.63589L7.82843 10.9999Z",
+    filled: "M12 13V20L4 12L12 4V11H20V13H12Z",
+  },
   arrowRight: {
     line: "M16.1716 10.9999L10.8076 5.63589L12.2218 4.22168L20 11.9999L12.2218 19.778L10.8076 18.3638L16.1716 12.9999H4V10.9999H16.1716Z",
     filled: "M12 13H4V11H12V4L20 12L12 20V13Z",

--- a/src/components/Stickers/Stickers.tsx
+++ b/src/components/Stickers/Stickers.tsx
@@ -12,26 +12,25 @@ export const Stickers = () => {
   const [exiting, setExiting] = useState(false);
   const $numSams = useStore(numSams);
 
-  const addSticker = () => {
-    const getNewSticker = () => ({
-      id: nanoid(),
-      variant: $numSams,
-    });
-    setStickers((prev) => [...prev, getNewSticker()]);
-  };
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: addSticker changes on every render and should not be used as a dependency
   useEffect(() => {
-    if ($numSams > stickers.length) addSticker();
-
-    if ($numSams === 0) setStickers([]);
-
-    if ($numSams > 2) {
-      setShowShoo(true);
-    } else {
+    if ($numSams === 0) {
+      setStickers([]);
       setShowShoo(false);
+      return;
     }
-  }, [$numSams, stickers]);
+
+    setShowShoo($numSams > 2);
+
+    if ($numSams > stickers.length) {
+      setStickers((prev) => [
+        ...prev,
+        {
+          id: nanoid(),
+          variant: $numSams,
+        },
+      ]);
+    }
+  }, [$numSams, stickers.length]);
 
   const handleShoo = () => {
     setExiting(true);

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,14 +1,44 @@
 ---
-import { Guestbook as GuestbookDB, db } from "astro:db";
-import dayjs from "dayjs";
-import Center from "src/components/Center.astro";
-
+import { Guestbook as GuestbookDB, db, desc } from "astro:db";
+import { Icon } from "src/components/Icon/Icon";
+import Center from "../components/Center.astro";
 import Notecard from "../components/Notecard/Notecard.astro";
 import { NotecardComposer } from "../components/Notecard/NotecardComposer";
 import BaseLayout from "../layouts/BaseLayout.astro";
 
 // Server-render page
 export const prerender = false;
+
+// Get the current page from search params
+const currentPage = Number(Astro.url.searchParams.get("page")) || 1;
+
+// Redirect page=1 to base URL
+if (currentPage === 1 && Astro.url.searchParams.has("page")) {
+  return Astro.redirect("/guestbook");
+}
+
+// Adjust entries per page based on whether we're on the first page
+const baseEntriesPerPage = 12;
+const entriesPerPage =
+  currentPage === 1 ? baseEntriesPerPage - 1 : baseEntriesPerPage;
+
+const totalEntries = (await db.select().from(GuestbookDB)).length;
+// Calculate total pages accounting for one less entry on first page
+const remainingEntries = Math.max(0, totalEntries - 1); // Subtract one for composer
+const totalPages = Math.max(
+  1,
+  Math.ceil(remainingEntries / baseEntriesPerPage),
+);
+const isFirstPage = currentPage === 1;
+const isLastPage = currentPage === totalPages;
+
+// Redirect if page number is invalid
+if (currentPage > totalPages) {
+  return Astro.redirect("/guestbook");
+}
+
+// Adjust offset calculation for pagination
+const offset = isFirstPage ? 0 : (currentPage - 1) * baseEntriesPerPage - 1;
 
 if (Astro.request.method === "POST") {
   const formData = await Astro.request.formData();
@@ -34,10 +64,16 @@ if (Astro.request.method === "POST") {
   }
 }
 
-const guestbook = await db.select().from(GuestbookDB);
-guestbook.sort((a, b) =>
-  dayjs(b.timestamp).isBefore(dayjs(a.timestamp)) ? -1 : 1,
-);
+const guestbook = await db
+  .select()
+  .from(GuestbookDB)
+  .orderBy(desc(GuestbookDB.timestamp))
+  .limit(entriesPerPage)
+  .offset(offset);
+
+if (guestbook.length === 0) {
+  return Astro.redirect("/guestbook");
+}
 
 const title = "Guestbook";
 const description = "Leave a message in eva.town.";
@@ -53,7 +89,7 @@ const description = "Leave a message in eva.town.";
 >
   <h1 class="visually-hidden">Guestbook</h1>
   <div class="notecards">
-    <NotecardComposer client:load />
+    {isFirstPage && <NotecardComposer client:load />}
     {
       guestbook.map(({ author, url, content, timestamp, theme }) => (
         <Notecard
@@ -66,13 +102,40 @@ const description = "Leave a message in eva.town.";
       ))
     }
   </div>
+  {isLastPage && (
+    <Center>
+      <div class="postscript">
+        You've reached the end! <a
+          href="/posts/design-outside-the-computer"
+          data-fathom="explanation"
+          >Learn how I created this guestbook.
+        </a>
+      </div>
+    </Center>
+  )}
   <Center>
-    <div class="postscript">
-      You've reached the end! <a
-        href="/posts/design-outside-the-computer"
-        data-fathom="explanation"
-        >Learn how I created this guestbook.
-      </a>
+    <div class="pagination">
+      <span>
+        Page {currentPage} of {totalPages}
+      </span>
+      <div class="pages">
+        {currentPage > 1 && (
+          <a 
+            aria-label="Previous page" 
+            href={currentPage === 2 ? '/guestbook' : `/guestbook?page=${currentPage - 1}`}
+          >
+            <Icon icon="arrowLeft" />
+          </a>
+        )}
+        {currentPage < totalPages && (
+          <a 
+            aria-label="Next page" 
+            href={`/guestbook?page=${currentPage + 1}`}
+          >
+            <Icon icon="arrowRight" />
+          </a>
+        )}
+      </div>
     </div>
   </Center>
 </BaseLayout>
@@ -91,6 +154,33 @@ const description = "Leave a message in eva.town.";
   .postscript {
     text-align: center;
     padding-block-start: var(--space-xl);
+  }
+
+  .pagination {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    text-align: center;
+    padding-block-start: var(--space-xl);
+
+    .pages {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: var(--space-s);
+    }
+
+    a {
+      cursor: pointer;
+      border-radius: var(--radius-full);
+      padding: var(--space-2xs) var(--space-m);
+      background-color: var(--gray-12);
+      color: var(--gray-1);
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2xs);
+    }
   }
 </style>
 

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,5 +1,5 @@
 ---
-import { Guestbook as GuestbookDB, db, desc } from "astro:db";
+import { Guestbook as GuestbookDB, count, db, desc } from "astro:db";
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
 import Notecard from "../components/Notecard/Notecard.astro";
@@ -18,11 +18,12 @@ if (currentPage === 1 && Astro.url.searchParams.has("page")) {
 }
 
 // Adjust entries per page based on whether we're on the first page
-const baseEntriesPerPage = 12;
+const baseEntriesPerPage = 24;
 const entriesPerPage =
   currentPage === 1 ? baseEntriesPerPage - 1 : baseEntriesPerPage;
 
-const totalEntries = (await db.select().from(GuestbookDB)).length;
+const entryCount = await db.select({ count: count() }).from(GuestbookDB);
+const totalEntries = entryCount[0].count;
 // Calculate total pages accounting for one less entry on first page
 const remainingEntries = Math.max(0, totalEntries - 1); // Subtract one for composer
 const totalPages = Math.max(


### PR DESCRIPTION
- Paginate guestbook results to improve load time and minimize query calls
- Fix a bug with `useEffect` for `Stickers.tsx` that was causing infinite re-renders.