### PR TITLE
feat: Add basic spam filtering to Guestbook

### DIFF
--- a/db/config.ts
+++ b/db/config.ts
@@ -8,6 +8,7 @@ const Guestbook = defineTable({
     url: column.text({ optional: true }),
     timestamp: column.date({ default: NOW }),
     theme: column.number(),
+    isSpam: column.boolean({ optional: true }),
   },
 });
 

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,13 +1,5 @@
 ---
-import {
-  Guestbook as GuestbookDB,
-  count,
-  db,
-  desc,
-  eq,
-  isNull,
-  or,
-} from "astro:db";
+import { Guestbook as GuestbookDB, count, db, desc, eq } from "astro:db";
 
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,5 +1,13 @@
 ---
-import { Guestbook as GuestbookDB, count, db, desc, eq } from "astro:db";
+import {
+  Guestbook as GuestbookDB,
+  count,
+  db,
+  desc,
+  eq,
+  isNull,
+  or,
+} from "astro:db";
 
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
@@ -26,7 +34,7 @@ const entriesPerPage =
 const entryCount = await db
   .select({ count: count() })
   .from(GuestbookDB)
-  .where(eq(GuestbookDB.isSpam, false));
+  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)));
 const totalEntries = entryCount[0].count;
 // Calculate total pages accounting for one less entry on first page
 const remainingEntries = Math.max(0, totalEntries - 1); // Subtract one for composer
@@ -75,7 +83,7 @@ if (Astro.request.method === "POST") {
 const guestbook = await db
   .select()
   .from(GuestbookDB)
-  .where(eq(GuestbookDB.isSpam, false))
+  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)))
   .orderBy(desc(GuestbookDB.timestamp))
   .limit(entriesPerPage)
   .offset(offset);

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,5 +1,13 @@
 ---
-import { Guestbook as GuestbookDB, count, db, desc, eq } from "astro:db";
+import {
+  Guestbook as GuestbookDB,
+  count,
+  db,
+  desc,
+  eq,
+  isNull,
+  or,
+} from "astro:db";
 import { not } from "astro:db";
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
@@ -23,7 +31,10 @@ const baseEntriesPerPage = 24;
 const entriesPerPage =
   currentPage === 1 ? baseEntriesPerPage - 1 : baseEntriesPerPage;
 
-const entryCount = await db.select({ count: count() }).from(GuestbookDB);
+const entryCount = await db
+  .select({ count: count() })
+  .from(GuestbookDB)
+  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)));
 const totalEntries = entryCount[0].count;
 // Calculate total pages accounting for one less entry on first page
 const remainingEntries = Math.max(0, totalEntries - 1); // Subtract one for composer
@@ -72,7 +83,7 @@ if (Astro.request.method === "POST") {
 const guestbook = await db
   .select()
   .from(GuestbookDB)
-  .where(not(eq(GuestbookDB.isSpam, true)))
+  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)))
   .orderBy(desc(GuestbookDB.timestamp))
   .limit(entriesPerPage)
   .offset(offset);

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -8,7 +8,6 @@ import {
   isNull,
   or,
 } from "astro:db";
-import { not } from "astro:db";
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
 import Notecard from "../components/Notecard/Notecard.astro";

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -1,5 +1,6 @@
 ---
-import { Guestbook as GuestbookDB, count, db, desc } from "astro:db";
+import { Guestbook as GuestbookDB, count, db, desc, eq } from "astro:db";
+import { not } from "astro:db";
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
 import Notecard from "../components/Notecard/Notecard.astro";
@@ -57,9 +58,12 @@ if (Astro.request.method === "POST") {
     typeof url === "string" &&
     typeof theme === "string"
   ) {
+    // Extremely basic spam filtering to protect against bots
+    const isSpam = content.includes("<a href") || content.includes("href=");
+
     await db
       .insert(GuestbookDB)
-      .values({ author, content, url, theme: Number.parseInt(theme) });
+      .values({ author, content, url, theme: Number.parseInt(theme), isSpam });
 
     return Astro.redirect("/guestbook");
   }
@@ -68,6 +72,7 @@ if (Astro.request.method === "POST") {
 const guestbook = await db
   .select()
   .from(GuestbookDB)
+  .where(not(eq(GuestbookDB.isSpam, true)))
   .orderBy(desc(GuestbookDB.timestamp))
   .limit(entriesPerPage)
   .offset(offset);

--- a/src/pages/guestbook.astro
+++ b/src/pages/guestbook.astro
@@ -8,6 +8,7 @@ import {
   isNull,
   or,
 } from "astro:db";
+
 import { Icon } from "src/components/Icon/Icon";
 import Center from "../components/Center.astro";
 import Notecard from "../components/Notecard/Notecard.astro";
@@ -33,7 +34,7 @@ const entriesPerPage =
 const entryCount = await db
   .select({ count: count() })
   .from(GuestbookDB)
-  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)));
+  .where(eq(GuestbookDB.isSpam, false));
 const totalEntries = entryCount[0].count;
 // Calculate total pages accounting for one less entry on first page
 const remainingEntries = Math.max(0, totalEntries - 1); // Subtract one for composer
@@ -82,7 +83,7 @@ if (Astro.request.method === "POST") {
 const guestbook = await db
   .select()
   .from(GuestbookDB)
-  .where(or(eq(GuestbookDB.isSpam, false), isNull(GuestbookDB.isSpam)))
+  .where(eq(GuestbookDB.isSpam, false))
   .orderBy(desc(GuestbookDB.timestamp))
   .limit(entriesPerPage)
   .offset(offset);


### PR DESCRIPTION
Add a new `isSpam` column to the Guestbook table. Change flag to true when submissions include anchor link HTML fragments.