### PR TITLE
refactor: Improve heading levels

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
   "files": {
     "includes": [
       "**",

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -41,7 +41,7 @@ import { SubscribeForm } from "../Subscribe/SubscribeForm";
         >
       </div>
       <div class="banner">
-        <span class="emoji">🇵🇸</span>
+        <span class="emoji" aria-label="Palestinian flag">🇵🇸</span>
         <a
           href="https://www.jewishvoiceforpeace.org/"
           target="_blank"
@@ -107,16 +107,16 @@ import { SubscribeForm } from "../Subscribe/SubscribeForm";
 
     a {
       text-decoration: none;
+
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          color: var(--gray-12);
+        }
+      }
     }
 
     .emoji {
       transform: scale(1.5) translateY(0.04em);
-    }
-
-    @media (hover: hover) and (pointer: fine) {
-      &:hover {
-        color: var(--gray-12);
-      }
     }
   }
 

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -41,7 +41,7 @@ import { SubscribeForm } from "../Subscribe/SubscribeForm";
         >
       </div>
       <div class="banner">
-        <span class="emoji" aria-label="Palestinian flag">🇵🇸</span>
+        <span class="emoji">🇵🇸</span>
         <a
           href="https://www.jewishvoiceforpeace.org/"
           target="_blank"

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -30,10 +30,18 @@ const isModifiedSameDay = dayjs(datePublished).isSame(dateModified, "day");
         </div>
       )
     }
-    <h1 itemprop="name" class="page-title">
-      {title}
-    </h1>
-    {description && <p class="page-subtitle">{description}</p>}
+    <hgroup role="group" aria-roledescription="Heading group">
+      <h1 itemprop="name" class="page-title">
+        {title}
+      </h1>
+      {
+        description && (
+          <p aria-roledescription="subtitle" class="page-subtitle">
+            {description}
+          </p>
+        )
+      }
+    </hgroup>
     {
       datePublished && (
         <div class="date">

--- a/src/components/PostLink.astro
+++ b/src/components/PostLink.astro
@@ -25,7 +25,9 @@ const { url, title, description, datePublished, features } = Astro.props;
       </div>
     )
   }
-  <a href={url} class="title">{title}</a>
+  <h3 class="title">
+    <a href={url}>{title}</a>
+  </h3>
   <span class="description">{description}</span>
   {
     features && (

--- a/src/components/RelativeDate/RelativeDate.tsx
+++ b/src/components/RelativeDate/RelativeDate.tsx
@@ -5,11 +5,11 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 
-interface RelativeDateProps {
+interface RelativeDateProps extends React.HTMLAttributes<HTMLTimeElement> {
   date: Date | null;
 }
 
-export const RelativeDate = ({ date }: RelativeDateProps) => {
+export const RelativeDate = ({ date, ...props }: RelativeDateProps) => {
   dayjs.extend(utc);
   dayjs.extend(timezone); // Support 'z' to display timezone
   dayjs.extend(localizedFormat); // Support 'LLLL' to display full date
@@ -49,7 +49,7 @@ export const RelativeDate = ({ date }: RelativeDateProps) => {
   }
 
   return (
-    <time dateTime={dateTime} title={formattedTimestamp}>
+    <time dateTime={dateTime} title={formattedTimestamp} {...props}>
       {displayTime}
     </time>
   );

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -22,9 +22,9 @@ const description = "What’s Eva up to?";
         return (
           <li class="event">
             <div class="dot" aria-hidden />
-            <span class="heading">
+            <h2 class="heading">
               <RelativeDate date={event.data.date} client:load />
-            </span>
+            </h2>
             <div class="line" aria-hidden />
             <div class="content">
               <Content />
@@ -35,7 +35,7 @@ const description = "What’s Eva up to?";
     }
     <li class="event">
       <div class="dot" aria-hidden></div>
-      <span class="heading">Awhile ago</span>
+      <h2 class="heading">Awhile ago</h2>
       <div class="content">
         <p>
           I discovered <a href="https://nownownow.com/"
@@ -91,6 +91,8 @@ const description = "What’s Eva up to?";
     }
 
     .heading {
+      all: unset;
+      font-size: var(--step-0);
       color: var(--gray-11);
       grid-area: heading;
     }

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -14,6 +14,7 @@ const description = "What’s Eva up to?";
 ---
 
 <ProseLayout title={title} description={description}>
+  <h2 class="visually-hidden">Latest entries</h2>
   <ul class="events">
     {
       events.map(async (event) => {
@@ -22,9 +23,9 @@ const description = "What’s Eva up to?";
         return (
           <li class="event">
             <div class="dot" aria-hidden />
-            <h2 class="heading">
+            <span class="heading">
               <RelativeDate date={event.data.date} client:load />
-            </h2>
+            </span>
             <div class="line" aria-hidden />
             <div class="content">
               <Content />
@@ -35,7 +36,7 @@ const description = "What’s Eva up to?";
     }
     <li class="event">
       <div class="dot" aria-hidden></div>
-      <h2 class="heading">Awhile ago</h2>
+      <span class="heading">Awhile ago</span>
       <div class="content">
         <p>
           I discovered <a href="https://nownownow.com/"


### PR DESCRIPTION
Improve the accessibility of site headings:

1. Add `h3` to all blog titles and experiment titles on the `/garden` page
2. Add visually hidden heading on `/now` page
3. Wrap page titles and descriptions in an `hgroup` with appropriate ARIA roles: https://www.tpgi.com/subheadings-subtitles-alternative-titles-and-taglines-in-html/

| Before | After |
|--------|--------|
| <img width="304" height="218" alt="CleanShot 2025-08-08 at 12 36 15@2x" src="https://github.com/user-attachments/assets/d249a592-439f-4134-9bb5-3f42e36fbfa5" /> |<img width="616" height="788" alt="CleanShot 2025-08-08 at 12 36 41@2x" src="https://github.com/user-attachments/assets/b7c1e3e3-92fd-437b-810f-551c06ddee0e" /> |