### PR TITLE
feat: Improve carbon score, update colophon

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.3/schema.json",
   "files": {
     "includes": [
       "**",

--- a/src/content/pages/colophon/index.md
+++ b/src/content/pages/colophon/index.md
@@ -2,7 +2,7 @@
 title: Colophon
 description: Colophon is a designer-y word for “how it’s made”—here’s what powers eva.town.
 datePublished: 2023-09-26 03:47:00-04:00
-dateModified: 2024-11-08 01:47:39-05:00
+dateModified: 2025-09-12 20:42:28-04:00
 img: ["./img600.webp", "./img900.webp", "./img1200.webp"]
 imgAlt: The spines of 12 books, including Visual Explanations, The Display of Quantitative Information, The Geometry of Type, Understanding Comics, Nicely Said, Don't Make Me Think!, Queer by Design, The 99% Invisible City, Interaction of Color, The Elements of Style, Thinking Fast and Slow, and The Death and Life of Great American Cities.
 ogImage: ./img1200.webp
@@ -52,7 +52,7 @@ I minimize energy usage on this site by avoiding unnecessary scripts (such as tr
 > The internet consumes a lot of electricity. 416.2TWh per year to be precise. To give you some perspective, that's more than the entire United Kingdom.
 > <cite>[Website Carbon Calculator](https://www.websitecarbon.com)</cite>
 
-As of October 18, 2023, [carbon results for eva.town](https://www.websitecarbon.com/website/eva-town/) indicate that the home page is cleaner than 95% of web pages tested, producing 0.05g of CO<sub>2</sub> per page view.
+As of September 12, 2025, [carbon results for eva.town](https://www.websitecarbon.com/website/eva-town/) indicate that the home page is cleaner than 96% of web pages tested, producing **0.02g of CO<sub>2</sub>** per page view.
 
 ## Accessibility
 


### PR DESCRIPTION
Resolves #541. Closes #540.

Perf improvements in #634 greatly increased the Lighthouse score and, subsequently, the website carbon score. Update the colophon page to reflect new values.

Do not add a badge to the webrings page, since that involves adding an extra script.