### PR TITLE
Fix background on Bluesky embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
       "biome check --write"
     ]
   },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
+  },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/db": "0.21.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 allowBuilds:
-  esbuild: set this to true or false
-  sharp: set this to true or false
+  esbuild: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  esbuild: true
-  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: set this to true or false
+  sharp: set this to true or false

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -326,9 +326,7 @@
 }
 
 .bluesky-embed {
-  background: transparent;
-  /* Hide white background on Bluesky embeds in dark mode; match border radius */
-  border-radius: 0.75rem;
+  color-scheme: light;
   overflow: hidden;
   margin-inline: auto;
   /* biome-ignore lint/complexity/noImportantStyles: Necessary to override existing styles */


### PR DESCRIPTION
For some reason, inheriting `color-scheme: dark` sets the background of the iframe for the Bluesky embed to white. Overriding this with `color-scheme: light` on the embed itself solves the issue.