### PR TITLE
Improve error handling and confirmation for subscription form

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,6 @@
       "biome check --write"
     ]
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
-  },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/db": "0.21.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - ky.fyi
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -37,6 +37,7 @@ interface Remark {
 
 const TRIGGER_SOME_CHARACTERS_DIALOGUE_AT_LENGTH = 4;
 const REMARK_TIMEOUT = 1000;
+const SNIPER_SENDER = "hi@ky.fyi";
 
 const remarks: Record<RemarkType, Remark> = {
   intro: {
@@ -162,14 +163,16 @@ export const SubscribeForm = () => {
 
   const displayNewRemark = (
     remarkType: RemarkType,
-    options?: { force?: boolean },
+    options?: { force?: boolean; text?: string },
   ) => {
     const shouldDisplayNewRemark =
       options?.force === true || !justDisplayedRemarks;
 
     if (shouldDisplayNewRemark && remarkType !== currentRemarkType) {
       setCurrentRemarkType(remarkType);
-      setCurrentText(getRandomRemark(remarks[remarkType].text));
+      setCurrentText(
+        options?.text ?? getRandomRemark(remarks[remarkType].text),
+      );
       setCurrentEmote(remarks[remarkType].emote);
     }
   };
@@ -221,37 +224,38 @@ export const SubscribeForm = () => {
     setIsSubmitting(true);
     displayNewRemark("submitting", { force: true });
 
-    const url =
-      "https://buttondown.email/api/emails/embed-subscribe/notesfromky";
     const data = new FormData(e.target as HTMLFormElement);
 
-    fetch(url, { method: "POST", body: data })
-      .then((response) => {
+    fetch("/api/subscribe", { method: "POST", body: data })
+      .then(async (response) => {
         if (response.ok) {
-          setTimeout(() => {
-            displayNewRemark("success", { force: true });
-            setHasSubmitted(true);
-            setIsSubmitting(false);
-          }, 1500);
+          displayNewRemark("success", { force: true });
+          setHasSubmitted(true);
         } else {
-          console.error(response);
-          displayNewRemark("error", { force: true });
-          setIsSubmitting(false);
+          let errorText: string | undefined;
+          try {
+            const body = await response.json();
+            if (typeof body?.error === "string") errorText = body.error;
+          } catch {
+            // ignore
+          }
+          displayNewRemark("error", { force: true, text: errorText });
         }
       })
       .catch((error) => {
-        console.error(error);
+        console.error("Subscribe request failed:", error);
+        displayNewRemark("error", { force: true });
+      })
+      .finally(() => {
+        setIsSubmitting(false);
       });
 
-    const sender = "hi@ky.fyi";
-    const sniperUrl = `https://sniperl.ink/v1/render?recipient=${recipientEmail}&sender=${sender}`;
-
-    fetch(sniperUrl)
+    fetch(
+      `https://sniperl.ink/v1/render?recipient=${recipientEmail}&sender=${SNIPER_SENDER}`,
+    )
       .then(async (response) => {
         if (response.ok) {
-          await response.json().then((data) => {
-            setSniperData(data);
-          });
+          setSniperData(await response.json());
         }
       })
       .catch((error) => {

--- a/src/components/Subscribe/SubscribeForm.tsx
+++ b/src/components/Subscribe/SubscribeForm.tsx
@@ -122,7 +122,13 @@ const remarks: Record<RemarkType, Remark> = {
     emote: "thinking",
   },
   success: {
-    text: ["yeah! get ready for e-mail (eva-mail)"],
+    text: [
+      "yeah! get ready for e-mail",
+      "i am INSIDE YOUR INBOX",
+      "woah. it worked",
+      "good job! we are linked together",
+      "subscribed. welcome to my home",
+    ],
     emote: "starstruck",
   },
   error: {

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,0 +1,53 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST = (async ({ request }) => {
+  const formData = await request.formData().catch(() => null);
+  if (!formData) {
+    return new Response(JSON.stringify({ error: "Invalid request" }), {
+      status: 400,
+    });
+  }
+
+  const email = formData.get("email");
+  if (typeof email !== "string" || !email) {
+    return new Response(JSON.stringify({ error: "Invalid email" }), {
+      status: 400,
+    });
+  }
+
+  const buttondownData = new FormData();
+  buttondownData.set("email", email);
+
+  const response = await fetch(
+    "https://buttondown.email/api/emails/embed-subscribe/notesfromky",
+    { method: "POST", body: buttondownData },
+  );
+
+  if (response.ok) {
+    return new Response(null, { status: 200 });
+  }
+
+  let errorMessage: string | undefined;
+  try {
+    const body = await response.json();
+    if (typeof body?.error === "string") errorMessage = body.error;
+  } catch {
+    // non-JSON error body — fall through to generic message
+  }
+
+  return new Response(
+    JSON.stringify({ error: errorMessage ?? "Something went wrong" }),
+    {
+      status: response.status,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}) satisfies APIRoute;
+
+export const ALL = (() => {
+  return new Response(JSON.stringify({ error: "Method not allowed" }), {
+    status: 405,
+  });
+}) satisfies APIRoute;


### PR DESCRIPTION
Create a new `/api/subscribe` proxy to forward to Buttondown server-to-server. Avoid CORS errors.

Pass error messages back to the UI, remove a timeout during submit.