### PR TITLE
Automatically populate `dateModified` time

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import cssnano from "cssnano";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import imgAttr from "remark-imgattr";
 import { autolinkConfig } from "./plugins/rehype-autolink-config";
+import { remarkModifiedTime } from "./plugins/remark-modified-time.mjs";
 
 export default defineConfig({
   site: "https://ky.fyi",
@@ -28,6 +29,7 @@ export default defineConfig({
   trailingSlash: "never",
   adapter: cloudflare({
     prerenderEnvironment: "node",
+    imageService: "passthrough",
   }),
   markdown: {
     processor: unified({
@@ -35,7 +37,7 @@ export default defineConfig({
         rehypeHeadingIds,
         [rehypeAutolinkHeadings, autolinkConfig],
       ],
-      remarkPlugins: [imgAttr],
+      remarkPlugins: [imgAttr, remarkModifiedTime],
     }),
   },
   vite: {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@astrojs/check": "^0.9.9",
     "@astrojs/cloudflare": "^13.7.0",
     "@astrojs/markdown-remark": "^7.2.0",
-    "@astrojs/mdx": "^5.0.3",
+    "@astrojs/mdx": "^6.0.3",
     "@astrojs/react": "^5.0.7",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",

--- a/plugins/remark-modified-time.mjs
+++ b/plugins/remark-modified-time.mjs
@@ -1,0 +1,9 @@
+import { execSync } from "node:child_process";
+
+export function remarkModifiedTime() {
+  return (_tree, file) => {
+    const filepath = file.history[0];
+    const result = execSync(`git log -1 --pretty="format:%cI" "${filepath}"`);
+    file.data.astro.frontmatter.dateModified = result.toString();
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^7.2.0
         version: 7.2.0
       '@astrojs/mdx':
-        specifier: ^5.0.3
-        version: 5.0.6(astro@6.4.5(@types/node@25.9.2)(jiti@2.7.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
+        specifier: ^6.0.3
+        version: 6.0.3(astro@6.4.5(@types/node@25.9.2)(jiti@2.7.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))
       '@astrojs/react':
         specifier: ^5.0.7
         version: 5.0.7(@types/node@25.9.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(jiti@2.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tsx@4.22.4)(yaml@2.9.0)
@@ -171,9 +171,6 @@ packages:
   '@astrojs/internal-helpers@0.10.0':
     resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
-  '@astrojs/internal-helpers@0.9.1':
-    resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
-
   '@astrojs/language-server@2.16.8':
     resolution: {integrity: sha512-yg1pZF6hs9FaKr2fgXMOGbW7pDLgFexFjuhWilPAc8VybTU+WSnbfbhYaUL1exm6dAK4sM3aKXGcfVwss+HXbg==}
     hasBin: true
@@ -186,17 +183,18 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@astrojs/markdown-remark@7.1.2':
-    resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
-
   '@astrojs/markdown-remark@7.2.0':
     resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
-  '@astrojs/mdx@5.0.6':
-    resolution: {integrity: sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==}
+  '@astrojs/mdx@6.0.3':
+    resolution: {integrity: sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
-      astro: ^6.0.0
+      '@astrojs/markdown-satteri': 0.3.0
+      astro: ^6.4.0
+    peerDependenciesMeta:
+      '@astrojs/markdown-satteri':
+        optional: true
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
@@ -4184,10 +4182,6 @@ snapshots:
       smol-toml: 1.6.1
       unified: 11.0.5
 
-  '@astrojs/internal-helpers@0.9.1':
-    dependencies:
-      picomatch: 4.0.4
-
   '@astrojs/language-server@2.16.8(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
       '@astrojs/compiler': 2.13.1
@@ -4213,32 +4207,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@astrojs/markdown-remark@7.1.2':
-    dependencies:
-      '@astrojs/internal-helpers': 0.9.1
-      '@astrojs/prism': 4.0.2
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      js-yaml: 4.2.0
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.2.0
-      smol-toml: 1.6.1
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@astrojs/markdown-remark@7.2.0':
     dependencies:
       '@astrojs/internal-helpers': 0.10.0
@@ -4261,9 +4229,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.6(astro@6.4.5(@types/node@25.9.2)(jiti@2.7.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))':
+  '@astrojs/mdx@6.0.3(astro@6.4.5(@types/node@25.9.2)(jiti@2.7.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.2
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
       astro: 6.4.5(@types/node@25.9.2)(jiti@2.7.0)(rollup@4.61.1)(tsx@4.22.4)(yaml@2.9.0)

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,7 +10,6 @@ export const collections = {
         title: z.string(),
         description: z.string(),
         datePublished: z.date(),
-        dateModified: z.date().optional(),
         previewImage: z
           .object({
             image: image(),
@@ -28,7 +27,6 @@ export const collections = {
         title: z.string(),
         description: z.string(),
         datePublished: z.date(),
-        dateModified: z.date().optional(),
         headerImage: z
           .object({
             image: image().array(),

--- a/src/content/pages/about/index.mdx
+++ b/src/content/pages/about/index.mdx
@@ -2,7 +2,6 @@
 title: About Ky
 description: Pushing pixels (non-derogatory).
 datePublished: 2023-10-03 01:03:55-04:00
-dateModified: 2026-04-23 09:06:33-04:00
 previewImage:
   image: ./img1200.webp
   alt: A pixelated screenshot of Ky's desktop. The Photobooth app is open, showing Ky's face.

--- a/src/content/pages/colophon/index.md
+++ b/src/content/pages/colophon/index.md
@@ -2,7 +2,6 @@
 title: Colophon
 description: Colophon is a designer-y word for “how it’s made”—here’s what powers ky.fyi.
 datePublished: 2023-09-26 03:47:00-04:00
-dateModified: 2026-06-10 03:47:00-04:00
 headerImage:
   image: ["./img600.webp", "./img900.webp", "./img1200.webp"]
   alt: The spines of 12 books, including Visual Explanations, The Display of Quantitative Information, The Geometry of Type, Understanding Comics, Nicely Said, Don't Make Me Think!, Queer by Design, The 99% Invisible City, Interaction of Color, The Elements of Style, Thinking Fast and Slow, and The Death and Life of Great American Cities.

--- a/src/content/posts/ai-burnout/index.mdx
+++ b/src/content/posts/ai-burnout/index.mdx
@@ -2,7 +2,6 @@
 title: Do I belong in tech anymore?
 description: On quitting, the spread of AI, and the loss of an ideal.
 datePublished: 2026-04-24 14:11:49-04:00
-dateModified: 2026-04-24 14:11:41-04:00
 previewImage:
   image: ./broken-phone.png
   alt: A hand holds an iPhone with a shattered glass exterior.

--- a/src/content/posts/boundaries-map/index.mdx
+++ b/src/content/posts/boundaries-map/index.mdx
@@ -2,7 +2,6 @@
 title: Mapping where districts start and end
 description: Helping BetaNYC map and query New York City's various civic boundaries.
 datePublished: 2024-02-13 01:53:27-04:00
-dateModified: 2024-05-15 02:17:43-04:00
 video:
   src: video/boundaries-map.mp4
   poster: video/boundaries-map-poster.png

--- a/src/content/posts/commonplace/index.mdx
+++ b/src/content/posts/commonplace/index.mdx
@@ -2,7 +2,6 @@
 title: Building Commonplace
 description: What goes into building a design system for healthcare?
 datePublished: 2024-01-13 01:13:17-04:00
-dateModified: 2024-05-20 03:29:20-04:00
 previewImage:
   image: ./commonplace.png
   alt: A collection of Commonplace components represented in Figma and in code.

--- a/src/content/posts/design-outside-the-computer/index.mdx
+++ b/src/content/posts/design-outside-the-computer/index.mdx
@@ -2,7 +2,6 @@
 title: Design outside the computer
 description: Your digital UI can come from the physical world.
 datePublished: 2024-05-20 13:30:34-04:00
-dateModified: 2024-05-28 12:18:08-04:00
 previewImage:
   image: ./notecard-progress.png
   alt: Two stamps sit beside small rectangular piece of cream-color card stock. There is a red stamp on the paper with a hand holding a match alight.

--- a/src/content/posts/embrace-friction/index.mdx
+++ b/src/content/posts/embrace-friction/index.mdx
@@ -2,7 +2,6 @@
 title: Embrace friction
 description: On letterpress, tech, and the power of going slow.
 datePublished: 2025-12-08 12:26:21-05:00
-dateModified: 2026-03-25 16:46:01-04:00
 previewImage:
   image: ./letterpress-workstation.jpg
   alt: A letterpress workstation showing a large wooden case full of metal type.

--- a/src/content/posts/genderswap/index.mdx
+++ b/src/content/posts/genderswap/index.mdx
@@ -2,7 +2,6 @@
 title: Creating a catalogue of gender-swapped song covers
 description: The making of Genderswap.fm, using SvelteKit, Supabase, and the Spotify Web API.
 datePublished: 2024-03-02 01:40:50-04:00
-dateModified: 2024-05-15 02:17:43-04:00
 previewImage:
   image: ./genderswap-fm.png
   alt: A collection of original and cover album art for different songs.

--- a/src/pages/[id].astro
+++ b/src/pages/[id].astro
@@ -18,22 +18,15 @@ export async function getStaticPaths() {
 
 const { page } = Astro.props;
 const { data } = page;
-const { Content } = await render(page);
-const {
-  title,
-  description,
-  datePublished,
-  dateModified,
-  headerImage,
-  previewImage,
-} = data;
+const { Content, remarkPluginFrontmatter } = await render(page);
+const { title, description, datePublished, headerImage, previewImage } = data;
 ---
 
 <ProseLayout
   title={title}
   description={description}
   datePublished={datePublished}
-  dateModified={dateModified}
+  dateModified={remarkPluginFrontmatter.dateModified}
   headerImage={headerImage}
   previewImage={previewImage}
 >

--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -22,10 +22,12 @@ export async function getStaticPaths() {
   }));
 }
 const { post, prev, next } = Astro.props;
-const { Content } = await render(post);
+const { Content, remarkPluginFrontmatter } = await render(post);
 
 const { data } = post;
-const { title, description, previewImage, datePublished, dateModified } = data;
+const { title, description, previewImage, datePublished } = data;
+
+console.log(remarkPluginFrontmatter);
 ---
 
 <ProseLayout
@@ -33,7 +35,7 @@ const { title, description, previewImage, datePublished, dateModified } = data;
   description={description}
   previewImage={previewImage}
   datePublished={datePublished}
-  dateModified={dateModified}
+  dateModified={remarkPluginFrontmatter.dateModified}
 >
   <Content />
   <div class="pagination" slot="after-prose">


### PR DESCRIPTION
Stop manually tracking `dateModified` for all content files; fetch from git automatically.