### PR TITLE
Tweak homepage text and theme background colors

### DIFF
--- a/public/scripts/preloadTheme.js
+++ b/public/scripts/preloadTheme.js
@@ -18,7 +18,7 @@ const setTheme = () => {
   if (metaTheme !== null)
     metaTheme.setAttribute(
       "content",
-      userPreference === "dark" ? "#111111" : "#FCFCFC",
+      userPreference === "dark" ? "#191919" : "#F9F9F9",
     );
 
   window.localStorage.setItem("theme", userPreference);

--- a/src/components/Header/Header.astro
+++ b/src/components/Header/Header.astro
@@ -124,7 +124,6 @@ const navigation = [
       color: var(--gray-12);
       padding: var(--space-xs) var(--space-s);
       border: none;
-      border-radius: var(--radius-full);
       cursor: pointer;
       transition: font-weight 0.2s ease-in-out;
 
@@ -168,6 +167,7 @@ const navigation = [
       width: 20px;
       height: 20px;
       padding-inline: var(--space-xs);
+      border-radius: var(--radius-full);
 
       .icon {
         transform-origin: 50% 200%;

--- a/src/components/Home/ProjectGrid.astro
+++ b/src/components/Home/ProjectGrid.astro
@@ -73,8 +73,12 @@ const { items } = Astro.props;
     padding-block-end: var(--space-xs);
 
     &:focus-visible {
-      outline: var(--gray-12) solid 2px;
-      outline-offset: 3px;
+      outline: none;
+
+      .project-thumbnail {
+        outline: var(--gray-12) solid 2px;
+        outline-offset: 4px;
+      }
     }
   }
 

--- a/src/components/Notecard/Notecard.astro
+++ b/src/components/Notecard/Notecard.astro
@@ -94,6 +94,7 @@ const backgroundImage = `url(${NOTECARD_THEMES[theme].src})`;
   .author {
     a {
       text-decoration-color: inherit;
+      outline-color: inherit;
     }
   }
 

--- a/src/layouts/UnstyledBase.astro
+++ b/src/layouts/UnstyledBase.astro
@@ -35,11 +35,11 @@ const pageTitle =
     <meta name="generator" content={Astro.generator} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="dark light" />
-    <meta name="theme-color" content="#FCFCFC" />
+    <meta name="theme-color" content="#F9F9F9" />
     <meta
       name="theme-color"
       media="(prefers-color-scheme: dark)"
-      content="#111111"
+      content="#191919"
     />
     <Font cssVariable="--font-sans" preload />
     <Font cssVariable="--font-mono" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,7 +41,7 @@ const writing = posts
       <div class="intro">
         <p>
           <strong><a href="/about">Ky Decker</a>&nbsp;</strong>{" "}
-          designs <abbr title="world-wide websites">WWW</abbr> and writes <abbr
+          designs <abbr title="world-wide websites">www</abbr> and writes <abbr
             title="cascading style sheets">CSS</abbr
           > in <abbr title="New York City">NYC</abbr> with{" "}
           <button type="button" data-sam-button>Samwise</button>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,6 +170,7 @@ const writing = posts
       abbr {
         cursor: help;
         text-decoration-color: var(--gray-8);
+        text-decoration-style: wavy;
         text-underline-offset: max(0.1em, 2.5px);
 
         @media (hover: hover) and (pointer: fine) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -159,7 +159,6 @@ const writing = posts
 
     .intro {
       padding-block: var(--space-2xl);
-      text-wrap: pretty;
       user-select: none;
 
       p {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -100,7 +100,7 @@ const writing = posts
     }
 
     function setupAbbr() {
-      document.querySelectorAll(".intro abbr[title]").forEach((abbr) => {
+      document.querySelectorAll<HTMLElement>(".intro abbr[title]").forEach((abbr) => {
         abbr.addEventListener("click", () => abbr.replaceWith(abbr.title));
       });
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,9 +40,9 @@ const writing = posts
       <h1 class="visuallyhidden">Ky designs and builds for the web</h1>
       <div class="intro">
         <p>
-          <strong><a href="/about">Ky Decker</a>&nbsp;</strong>{" "}
+          <strong><a href="/about">Ky Decker</a></strong>{" "}
           designs <abbr title="world-wide websites">www</abbr> and writes <abbr
-            title="cascading style sheets">CSS</abbr
+            title="Cascading Style Sheets">CSS</abbr
           > in <abbr title="New York City">NYC</abbr> with{" "}
           <button type="button" data-sam-button>Samwise</button>
         </p>
@@ -100,9 +100,11 @@ const writing = posts
     }
 
     function setupAbbr() {
-      document.querySelectorAll<HTMLElement>(".intro abbr[title]").forEach((abbr) => {
-        abbr.addEventListener("click", () => abbr.replaceWith(abbr.title));
-      });
+      document
+        .querySelectorAll<HTMLElement>(".intro abbr[title]")
+        .forEach((abbr) => {
+          abbr.addEventListener("click", () => abbr.replaceWith(abbr.title));
+        });
     }
 
     setupSam();

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -40,10 +40,11 @@ const writing = posts
       <h1 class="visuallyhidden">Ky designs and builds for the web</h1>
       <div class="intro">
         <p>
-          <strong><a href="/about">Ky Decker</a></strong> is a designer and web developer.
-          They live in NYC with <span class="nowrap"
-            ><button type="button" data-sam-button>Samwise</button>.</span
-          >
+          <strong><a href="/about">Ky Decker</a>&nbsp;</strong>{" "}
+          designs <abbr title="world-wide websites">WWW</abbr> and writes <abbr
+            title="cascading style sheets">CSS</abbr
+          > in <abbr title="New York City">NYC</abbr> with{" "}
+          <button type="button" data-sam-button>Samwise</button>
         </p>
       </div>
       <div class="synth">
@@ -98,9 +99,19 @@ const writing = posts
       samButton?.addEventListener("click", () => addSam());
     }
 
-    setupSam();
+    function setupAbbr() {
+      document.querySelectorAll(".intro abbr[title]").forEach((abbr) => {
+        abbr.addEventListener("click", () => abbr.replaceWith(abbr.title));
+      });
+    }
 
-    document.addEventListener("astro:after-swap", () => setupSam());
+    setupSam();
+    setupAbbr();
+
+    document.addEventListener("astro:after-swap", () => {
+      setupSam();
+      setupAbbr();
+    });
 
     document.addEventListener("astro:page-load", () => {
       document
@@ -146,13 +157,26 @@ const writing = posts
 
     .intro {
       padding-block: var(--space-2xl);
-      text-wrap: balance;
+      text-wrap: pretty;
       user-select: none;
 
       p {
-        font-size: var(--step-5);
+        font-size: var(--step-4);
         letter-spacing: var(--letter-spacing-condensed);
         line-height: var(--line-height-tight);
+        padding-block-end: var(--space-l);
+      }
+
+      abbr {
+        cursor: help;
+        text-decoration-color: var(--gray-8);
+        text-underline-offset: max(0.1em, 2.5px);
+
+        @media (hover: hover) and (pointer: fine) {
+          &:hover {
+            text-decoration-color: var(--gray-11);
+          }
+        }
       }
 
       a,

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -10,7 +10,7 @@ html {
 
 body {
   color: var(--gray-12);
-  background-color: var(--gray-1);
+  background-color: var(--gray-2);
   display: flex;
   min-height: 100%;
   position: relative;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -111,10 +111,6 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-.nowrap {
-  white-space: nowrap;
-}
-
 .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -326,7 +326,7 @@
 }
 
 .prose aside {
-  background-color: var(--gray-2);
+  background-color: var(--gray-3);
   border: 1px solid var(--gray-6);
   padding: var(--space-xl);
   margin-block: var(--space-xl);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -52,7 +52,7 @@
   --line-height-body: 1.5;
 
   /* Letter spacing */
-  --letter-spacing-condensed: -0.015em;
+  --letter-spacing-condensed: -0.02em;
   --letter-spacing-normal: 0;
   --letter-spacing-loose: 0.01em;
 


### PR DESCRIPTION
- Display a shorter header with expandable abbreviations using `<abbr>`.
- Lower the contrast for the background color on the site to help with readability, especially in dark mode.
- Relocate outlines for project thumbnails to only display around the thumbnail image itself.
- Remove some funky border radii on header elements.
- Make sure that keyboard focus outlines are visible on notecards when in dark mode.

<img width="1738" height="358" alt="CleanShot 2026-07-08 at 23 39 31@2x" src="https://github.com/user-attachments/assets/bc160f1e-3738-442d-bafd-ea93f219b018" />