### PR TITLE
Make `aside` full-bleed on small viewports

### DIFF
--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -335,7 +335,7 @@
     margin-top: 0;
   }
 
-  @media (width < 720px) {
+  @media (width < 620px) {
     width: 100%;
     grid-column: 1 / -1;
     border-inline: none;

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -325,7 +325,7 @@
   }
 }
 
-.prose aside {
+.prose > aside {
   background-color: var(--gray-3);
   border: 1px solid var(--gray-6);
   padding: var(--space-xl);
@@ -333,6 +333,12 @@
 
   *:first-child {
     margin-top: 0;
+  }
+
+  @media (width < 720px) {
+    width: 100%;
+    grid-column: 1 / -1;
+    border-inline: none;
   }
 }
 


### PR DESCRIPTION
Let `aside` span edge-to-edge on small screens to prevent text from wrapping into too-small columns.