### PR TITLE
Modify code embed font sizes and condense post descriptions

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
       styleOverrides: {
         codeFontFamily:
           "'MonoLisa', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
+        codeFontSize: "0.85em",
+        uiFontSize: "0.9em",
       },
     }),
     mdx(),

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -83,14 +83,13 @@ const isModifiedSameDay = dayjs(datePublished).isSame(dateModified, "day");
   .page-title {
     padding-block-start: var(--space-2xl);
     line-height: var(--line-height-display);
-    text-wrap: pretty;
   }
 
   .page-subtitle {
     font-size: var(--step-2);
     line-height: var(--line-height-tight);
     padding-block-start: var(--space-xs);
-    text-wrap: balance;
+    text-wrap: pretty;
   }
 
   .date {

--- a/src/content/posts/boundaries-map/index.mdx
+++ b/src/content/posts/boundaries-map/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mapping where districts start and end
-description: Helping BetaNYC map and query New York City's various civic boundaries.
+description: Helping BetaNYC map and query New York City's civic boundaries.
 datePublished: 2024-02-13 01:53:27-04:00
 video:
   src: video/boundaries-map.mp4

--- a/src/content/posts/commonplace/index.mdx
+++ b/src/content/posts/commonplace/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Building Commonplace
-description: What goes into building a design system for healthcare?
+description: A design system for care teams at Cityblock.
 datePublished: 2024-01-13 01:13:17-04:00
 previewImage:
   image: ./commonplace.png

--- a/src/content/posts/genderswap/index.mdx
+++ b/src/content/posts/genderswap/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Creating a catalogue of gender-swapped song covers
-description: The making of Genderswap.fm, using SvelteKit, Supabase, and the Spotify Web API.
+title: Making Genderswap.fm
+description: On creating a catalogue of song covers.
 datePublished: 2024-03-02 01:40:50-04:00
 previewImage:
   image: ./genderswap-fm.png

--- a/src/content/posts/trauma-informed-design/index.mdx
+++ b/src/content/posts/trauma-informed-design/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: To build gentler technology, practice trauma-informed design
-description: By understanding trauma, we can craft user experiences that are more sensitive to the needs of everyone.
+description: Understanding trauma helps craft gentler user experiences.
 datePublished: 2021-05-13 00:00:00-04:00
 previewImage:
   image: ./cover.webp

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -52,7 +52,7 @@
   --line-height-body: 1.5;
 
   /* Letter spacing */
-  --letter-spacing-condensed: -0.02em;
+  --letter-spacing-condensed: -0.0175em;
   --letter-spacing-normal: 0;
   --letter-spacing-loose: 0.01em;
 


### PR DESCRIPTION
- Explicitly set a font size for expressive code to track closer to the body size of text
- Remove `text-wrap: balance` from the title and description in the page headers, which was creating odd wraps on mobile due to the size of text and narrowness of the screen
- Make descriptions to use `text-wrap: pretty` to keep at least two words on the final line but otherwise wrap normally
- Slightly loosen the "condensed" letter spacing token
- Revise and condense several post descriptions.