### PR TITLE
Link headings instead of using SVG link icon

### DIFF
--- a/plugins/rehype-autolink-config.ts
+++ b/plugins/rehype-autolink-config.ts
@@ -1,27 +1,5 @@
-import { h } from "hastscript";
 import type { Options } from "rehype-autolink-headings/";
 
-const AnchorLinkIcon = h(
-  "svg",
-  {
-    width: 24,
-    height: 24,
-    version: 1.1,
-    viewBox: "0 0 24 24",
-    xlmns: "http://www.w3.org/2000/svg",
-  },
-  h("path", {
-    fillRule: "evenodd",
-    fill: "currentcolor",
-    d: "M17.6572 14.8282L16.2429 13.414L17.6572 11.9998C19.2193 10.4377 19.2193 7.90506 17.6572 6.34296C16.0951 4.78086 13.5624 4.78086 12.0003 6.34296L10.5861 7.75717L9.17188 6.34296L10.5861 4.92875C12.9292 2.5856 16.7282 2.5856 19.0714 4.92875C21.4145 7.27189 21.4145 11.0709 19.0714 13.414L17.6572 14.8282ZM14.8287 17.6567L13.4145 19.0709C11.0714 21.414 7.27238 21.414 4.92923 19.0709C2.58609 16.7277 2.58609 12.9287 4.92923 10.5856L6.34345 9.17139L7.75766 10.5856L6.34345 11.9998C4.78135 13.5619 4.78135 16.0946 6.34345 17.6567C7.90555 19.2188 10.4382 19.2188 12.0003 17.6567L13.4145 16.2425L14.8287 17.6567ZM14.8287 7.75717L16.2429 9.17139L9.17188 16.2425L7.75766 14.8282L14.8287 7.75717Z",
-  }),
-);
-
 export const autolinkConfig: Options = {
-  behavior: "append",
-  group: ({ tagName }) =>
-    h(`div.heading-wrapper.level-${tagName}`, {
-      tabIndex: -1,
-    }),
-  content: [AnchorLinkIcon],
+  behavior: "wrap",
 };

--- a/src/content/posts/genderswap/index.mdx
+++ b/src/content/posts/genderswap/index.mdx
@@ -45,7 +45,7 @@ I listened to each cover and original, enamored with how lyrics could completely
 
 I began compiling Paul's songs into a playlist, and then I added more of my own. And more. And more. For another two years.
 
-## The Challenge
+## The challenge
 
 As my covers playlist grew, so did the tedium of managing it in Spotify. I kept all covers alphabetized (by hand), and I maintained two separate playlists—one for both [covers and originals](https://open.spotify.com/playlist/5YQ4AyxQ6DeDxKJgSryAU2?si=68e701a76c854e5c), and another for [covers only](https://open.spotify.com/playlist/50iUGmY3cSUETCHGfUgf6a?si=f078e27420334399).
 

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -51,38 +51,23 @@
   scroll-margin-top: var(--space-3xl);
 }
 
-.prose h1 a,
 .prose h2 a,
 .prose h3 a,
 .prose h4 a,
 .prose h5 a,
 .prose h6 a {
-  color: var(--gray-9);
-  display: inline-block;
-  margin-inline-start: 0.25em;
-  position: relative;
+  text-decoration-color: transparent;
+  text-decoration-skip-ink: none;
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .prose h1 a:hover,
   .prose h2 a:hover,
   .prose h3 a:hover,
   .prose h4 a:hover,
   .prose h5 a:hover,
   .prose h6 a:hover {
-    color: var(--gray-12);
+    text-decoration-color: var(--gray-7);
   }
-}
-
-.prose h1 a svg,
-.prose h2 a svg,
-.prose h3 a svg,
-.prose h4 a svg,
-.prose h5 a svg,
-.prose h6 a svg {
-  width: 0.75em;
-  height: 0.75em;
-  margin-bottom: -0.05em;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -95,7 +80,7 @@
 }
 
 .prose :not(hr) + h2:not(:first-child) {
-  margin-top: var(--space-2xl);
+  margin-top: var(--space-3xl);
 }
 
 .prose h2 + p,
@@ -325,7 +310,7 @@
   grid-column: popout;
   margin-block: var(--space-xl);
 
-  *:first-child,
+  &:first-child,
   + aside {
     margin-top: 0;
   }


### PR DESCRIPTION
Remove the trailing link icon from headings on blog posts. Link the entire heading instead.